### PR TITLE
chore: add a baseline public-readiness hygiene pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,11 @@ site/
 # mypy
 .mypy_cache/
 .dmypy.json
+.ruff_cache/
 
 # Coverage reports
 .coverage
+.coverage.*
 htmlcov/
 .pytest_cache/
 nosetests.xml
@@ -65,10 +67,15 @@ media-manager.db-wal
 .env.local
 .env.*
 !.env.sample
+!.env.example
+.envrc
 
 # Benchmark artifacts
 artifacts/perf/
 artifacts/
+
+# Frontend build output
+operator_console/gui_app/dist/
 
 # Local manual-QA media fixture output
 testdata/manual-qa/

--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,6 @@ media-manager.db-wal
 .env.local
 .env.*
 !.env.sample
-!.env.example
 .envrc
 
 # Benchmark artifacts

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The project is designed for restart safety, idempotent operations, and operator visibility. It is built around a FastAPI-backed application service, an HTTP-first operator console, structured documentation, and observability hooks for production-style workflows.
 
+Status: early-stage and still evolving toward a broader public release. Expect active changes in workflows, operator UX, and documentation while the core safety model remains the anchor.
+
 ## Key capabilities
 
 - Deterministic planning that produces reproducible planned actions for identical inputs.
@@ -78,7 +80,7 @@ pip install -e ".[docs]"
 
 ### Configure the environment
 
-Use the repository template:
+Use the committed example template to create a local-only runtime file:
 
 ```bash
 cp .env.sample .env
@@ -92,6 +94,16 @@ TEST_DATABASE_URL='postgresql+psycopg://user:password@localhost:5432/media_manag
 ```
 
 `DATABASE_URL` is required for runtime operation. Full variable reference: [documentation/reference/environment-variables.md](documentation/reference/environment-variables.md).
+
+Keep `.env` local to your machine. It is ignored by Git and should not be committed.
+
+### Initialize the database schema
+
+Apply the Alembic migrations before starting the API:
+
+```bash
+alembic upgrade head
+```
 
 ### Start the API service
 
@@ -154,6 +166,7 @@ source .venv/bin/activate
 cp .env.sample .env
 # Edit .env with PostgreSQL connection details first.
 
+alembic upgrade head
 media-manager-api &
 # Review the API response and note data.result.run_id from the plan request.
 
@@ -240,13 +253,15 @@ Run tests:
 ./.venv/bin/python -m pytest
 ```
 
+Tests expect `TEST_DATABASE_URL` to point at a PostgreSQL database prepared for local test runs.
+
 Build the docs:
 
 ```bash
 ./.venv/bin/python -m mkdocs build --strict
 ```
 
-Contribution workflow, branch conventions, review expectations, and merge policy are documented in [CONTRIBUTING.md](CONTRIBUTING.md).
+Contribution workflow, branch conventions, review expectations, and merge policy are documented in [CONTRIBUTING.md](CONTRIBUTING.md). The public contribution process is still settling; use the existing docs as the current baseline rather than a final external contributor guide.
 
 ## Safety model and invariants
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ curl -X POST http://127.0.0.1:8000/api/apply \
 source .venv/bin/activate
 cp .env.sample .env
 # Edit .env with PostgreSQL connection details first.
+# IMPORTANT: Create the PostgreSQL database before running migrations.
+# For example, if using the default media_manager_db:
+#   createdb media_manager_db
+# Ensure the database and connection details in .env match before proceeding.
 
 alembic upgrade head
 media-manager-api &
@@ -209,6 +213,7 @@ Use these docs for operational details instead of relying on the README for endp
 - [Observability guide](documentation/operator-guide/observability.md)
 
 Internal note:
+
 - The supported benchmark interface is the admin API plus `media-manager-benchmark-worker`. The old `tools/perf/*` scripts have been removed.
 
 ## Project structure

--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ Keep `.env` local to your machine. It is ignored by Git and should not be commit
 
 ### Initialize the database schema
 
-Apply the Alembic migrations before starting the API:
+Before running Alembic, ensure the PostgreSQL database referenced by `DATABASE_URL` exists. Create it if needed:
+
+```bash
+createdb media_manager_db
+```
+
+Verify that `DATABASE_URL` in `.env` is correct and points to an accessible PostgreSQL instance. Then apply the Alembic migrations:
 
 ```bash
 alembic upgrade head

--- a/documentation/architecture/duplicate-integrity-decisioning-implementation-plan.md
+++ b/documentation/architecture/duplicate-integrity-decisioning-implementation-plan.md
@@ -40,10 +40,10 @@ The current implementation already has clear read-model assembly points for dupl
 
 Primary current backend touchpoints:
 
-- [media_manager/app/persistence/operator_console.py](/home/harish/projects/media-manager/media_manager/app/persistence/operator_console.py)
+- `media_manager/app/persistence/operator_console.py`
   - `DuplicateGroupItem`
   - `OperatorConsoleReadService.get_duplicate_groups()`
-- [media_manager/app/service_layer/reads.py](/home/harish/projects/media-manager/media_manager/app/service_layer/reads.py)
+- `media_manager/app/service_layer/reads.py`
   - `ReadFacade.duplicates()`
 
 Current responsibilities in `get_duplicate_groups()`:
@@ -63,7 +63,7 @@ There is no separate backend "ready for bin" read path today. Current readiness 
 
 - `DuplicateGroupItem.duplicate_reclaim_actionable`
 - `DuplicateGroupItem.duplicate_reclaim_unavailable_reason`
-- frontend filtering in [operator_console/gui_app/src/pages/DuplicatesPage.tsx](/home/harish/projects/media-manager/operator_console/gui_app/src/pages/DuplicatesPage.tsx)
+- frontend filtering in `operator_console/gui_app/src/pages/DuplicatesPage.tsx`
   - `deriveActionableReadyGroups(...)`
   - `isPendingRemovalStatus(...)`
 
@@ -73,10 +73,10 @@ This means current "Ready for Bin" semantics are partly server-derived and partl
 
 Primary backend touchpoints:
 
-- [media_manager/app/persistence/operator_console.py](/home/harish/projects/media-manager/media_manager/app/persistence/operator_console.py)
+- `media_manager/app/persistence/operator_console.py`
   - `OperatorConsoleReadService.get_duplicate_reclaim_archive_page()`
   - `OperatorConsoleReadService.get_retention_recycle_page()`
-- [media_manager/app/service_layer/reads.py](/home/harish/projects/media-manager/media_manager/app/service_layer/reads.py)
+- `media_manager/app/service_layer/reads.py`
   - `ReadFacade.duplicate_bin_items()`
   - `ReadFacade.retention_recycle_items()`
 
@@ -86,11 +86,11 @@ These already expose authoritative duplicate-bin lifecycle facts but do not add 
 
 Primary backend touchpoints:
 
-- [media_manager/app/persistence/operator_console.py](/home/harish/projects/media-manager/media_manager/app/persistence/operator_console.py)
+- `media_manager/app/persistence/operator_console.py`
   - `IntegrityIssueItem`
   - `OperatorConsoleReadService.get_integrity_issue_page()`
   - `OperatorConsoleReadService.get_integrity_file_detail()`
-- [media_manager/app/service_layer/reads.py](/home/harish/projects/media-manager/media_manager/app/service_layer/reads.py)
+- `media_manager/app/service_layer/reads.py`
   - `ReadFacade.integrity_issues()`
   - `ReadFacade.integrity_file_detail()`
 
@@ -144,12 +144,12 @@ Current lifecycle read paths:
 
 Current GUI integration points:
 
-- [operator_console/gui_app/src/types/media.ts](/home/harish/projects/media-manager/operator_console/gui_app/src/types/media.ts)
+- `operator_console/gui_app/src/types/media.ts`
   - `DuplicateGroup`
   - `IntegrityIssue`
-- [operator_console/gui_app/src/lib/api/mappers/media.ts](/home/harish/projects/media-manager/operator_console/gui_app/src/lib/api/mappers/media.ts)
+- `operator_console/gui_app/src/lib/api/mappers/media.ts`
   - duplicate group mapping from backend JSON
-- [operator_console/gui_app/src/pages/DuplicatesPage.tsx](/home/harish/projects/media-manager/operator_console/gui_app/src/pages/DuplicatesPage.tsx)
+- `operator_console/gui_app/src/pages/DuplicatesPage.tsx`
   - current readiness filtering and action enablement
 
 These are the exact client seams that would consume additive recommendation fields later.
@@ -158,7 +158,7 @@ These are the exact client seams that would consume additive recommendation fiel
 
 ### Recommendation
 
-The first implementation should derive recommendation state in the backend read-model layer, centered in [media_manager/app/persistence/operator_console.py](/home/harish/projects/media-manager/media_manager/app/persistence/operator_console.py).
+The first implementation should derive recommendation state in the backend read-model layer, centered in `media_manager/app/persistence/operator_console.py`.
 
 ### Why backend read-model derivation is the right first seam
 
@@ -567,12 +567,12 @@ Can wait:
 
 Likely code areas:
 
-- [media_manager/app/persistence/operator_console.py](/home/harish/projects/media-manager/media_manager/app/persistence/operator_console.py)
+- `media_manager/app/persistence/operator_console.py`
 - new backend helper module, recommended:
   - `media_manager/app/persistence/duplicate_integrity_recommendations.py`
-- [media_manager/app/service_layer/reads.py](/home/harish/projects/media-manager/media_manager/app/service_layer/reads.py)
+- `media_manager/app/service_layer/reads.py`
 - backend tests near:
-  - [media_manager/tests/test_operator_console_duplicates.py](/home/harish/projects/media-manager/media_manager/tests/test_operator_console_duplicates.py)
+  - `media_manager/tests/test_operator_console_duplicates.py`
 
 Expected change type later:
 
@@ -594,11 +594,11 @@ Rollback/safety:
 
 Likely code areas:
 
-- [operator_console/gui_app/src/types/media.ts](/home/harish/projects/media-manager/operator_console/gui_app/src/types/media.ts)
-- [operator_console/gui_app/src/lib/api/mappers/media.ts](/home/harish/projects/media-manager/operator_console/gui_app/src/lib/api/mappers/media.ts)
-- [operator_console/gui_app/src/pages/DuplicatesPage.tsx](/home/harish/projects/media-manager/operator_console/gui_app/src/pages/DuplicatesPage.tsx)
+- `operator_console/gui_app/src/types/media.ts`
+- `operator_console/gui_app/src/lib/api/mappers/media.ts`
+- `operator_console/gui_app/src/pages/DuplicatesPage.tsx`
 - GUI tests near:
-  - [operator_console/gui_app/src/test/duplicates-page.test.tsx](/home/harish/projects/media-manager/operator_console/gui_app/src/test/duplicates-page.test.tsx)
+  - `operator_console/gui_app/src/test/duplicates-page.test.tsx`
 
 Expected change type later:
 
@@ -618,8 +618,8 @@ Rollback/safety:
 
 Likely code areas:
 
-- [media_manager/app/persistence/operator_console.py](/home/harish/projects/media-manager/media_manager/app/persistence/operator_console.py)
-- [media_manager/app/service_layer/reads.py](/home/harish/projects/media-manager/media_manager/app/service_layer/reads.py)
+- `media_manager/app/persistence/operator_console.py`
+- `media_manager/app/service_layer/reads.py`
 - frontend duplicate/bin and integrity page types/mappers/pages
 
 Expected change type later:
@@ -687,8 +687,8 @@ Recommended coverage:
 
 Recommended future locations:
 
-- [media_manager/tests/test_operator_console_duplicates.py](/home/harish/projects/media-manager/media_manager/tests/test_operator_console_duplicates.py)
-- [media_manager/tests/test_service_layer_reads.py](/home/harish/projects/media-manager/media_manager/tests/test_service_layer_reads.py)
+- `media_manager/tests/test_operator_console_duplicates.py`
+- `media_manager/tests/test_service_layer_reads.py`
 
 These should cover:
 
@@ -700,7 +700,7 @@ These should cover:
 
 Recommended future locations:
 
-- [operator_console/gui_app/src/test/duplicates-page.test.tsx](/home/harish/projects/media-manager/operator_console/gui_app/src/test/duplicates-page.test.tsx)
+- `operator_console/gui_app/src/test/duplicates-page.test.tsx`
 - frontend tests for any playback-issues page consuming duplicate context
 
 These should cover:
@@ -714,8 +714,8 @@ These should cover:
 
 Existing backend suites that should remain green:
 
-- [media_manager/tests/test_phase3_duplicate_reclaim.py](/home/harish/projects/media-manager/media_manager/tests/test_phase3_duplicate_reclaim.py)
-- [media_manager/tests/test_operator_console_duplicates.py](/home/harish/projects/media-manager/media_manager/tests/test_operator_console_duplicates.py)
+- `media_manager/tests/test_phase3_duplicate_reclaim.py`
+- `media_manager/tests/test_operator_console_duplicates.py`
 
 Implementation must prove:
 

--- a/documentation/architecture/duplicate-integrity-decisioning-spec.md
+++ b/documentation/architecture/duplicate-integrity-decisioning-spec.md
@@ -14,7 +14,7 @@ The current duplicate operator experience exposes:
 
 That gives the operator raw fragments, but not a system recommendation.
 
-Today the duplicate group read model in [operator_console.py](/home/harish/projects/media-manager/media_manager/app/persistence/operator_console.py) exposes:
+Today the duplicate group read model in `media_manager/app/persistence/operator_console.py` exposes:
 
 - `review_status`
 - `reclaim_status`
@@ -672,7 +672,7 @@ For duplicate group reads, add derived fields such as:
 - `suspect_extra_count`
 - `broken_extra_count`
 
-These should be computed in service/read paths close to current duplicate group assembly in [operator_console.py](/home/harish/projects/media-manager/media_manager/app/persistence/operator_console.py).
+These should be computed in service/read paths close to current duplicate group assembly in `media_manager/app/persistence/operator_console.py`.
 
 They should not replace:
 

--- a/documentation/architecture/duplicate-recycle-bin-persistence-migration-spec.md
+++ b/documentation/architecture/duplicate-recycle-bin-persistence-migration-spec.md
@@ -26,15 +26,15 @@ This is a persistence/storage migration spec, not an API contract migration spec
 
 This inventory is grounded in the current implementation:
 
-- [media_manager/app/persistence/models.py](/home/harish/projects/media-manager/media_manager/app/persistence/models.py)
-- [media_manager/app/persistence/phase3_actions.py](/home/harish/projects/media-manager/media_manager/app/persistence/phase3_actions.py)
-- [media_manager/app/persistence/apply.py](/home/harish/projects/media-manager/media_manager/app/persistence/apply.py)
-- [media_manager/app/persistence/policy_settings.py](/home/harish/projects/media-manager/media_manager/app/persistence/policy_settings.py)
-- [media_manager/app/persistence/operator_console.py](/home/harish/projects/media-manager/media_manager/app/persistence/operator_console.py)
-- [migrations/versions/0024_integrity_and_duplicate_reclaim.py](/home/harish/projects/media-manager/migrations/versions/0024_integrity_and_duplicate_reclaim.py)
-- [migrations/versions/0025_phase3_reclaim_and_quarantine_records.py](/home/harish/projects/media-manager/migrations/versions/0025_phase3_reclaim_and_quarantine_records.py)
-- [migrations/versions/0026_recycle_bin_soft_delete.py](/home/harish/projects/media-manager/migrations/versions/0026_recycle_bin_soft_delete.py)
-- [migrations/versions/0028_phase5_integrity_reclaim_policy_controls.py](/home/harish/projects/media-manager/migrations/versions/0028_phase5_integrity_reclaim_policy_controls.py)
+- `media_manager/app/persistence/models.py`
+- `media_manager/app/persistence/phase3_actions.py`
+- `media_manager/app/persistence/apply.py`
+- `media_manager/app/persistence/policy_settings.py`
+- `media_manager/app/persistence/operator_console.py`
+- `migrations/versions/0024_integrity_and_duplicate_reclaim.py`
+- `migrations/versions/0025_phase3_reclaim_and_quarantine_records.py`
+- `migrations/versions/0026_recycle_bin_soft_delete.py`
+- `migrations/versions/0028_phase5_integrity_reclaim_policy_controls.py`
 
 ### Current persisted duplicate-removal entities
 

--- a/documentation/architecture/duplicate-recycle-bin-persistence-phase5-cleanup-spec.md
+++ b/documentation/architecture/duplicate-recycle-bin-persistence-phase5-cleanup-spec.md
@@ -29,15 +29,15 @@ Non-goals:
 
 This plan is grounded in the current post-Phase-4 implementation:
 
-- [media_manager/app/persistence/models.py](/home/harish/projects/media-manager/media_manager/app/persistence/models.py)
-- [media_manager/app/persistence/phase3_actions.py](/home/harish/projects/media-manager/media_manager/app/persistence/phase3_actions.py)
-- [media_manager/app/persistence/apply.py](/home/harish/projects/media-manager/media_manager/app/persistence/apply.py)
-- [media_manager/app/persistence/operator_console.py](/home/harish/projects/media-manager/media_manager/app/persistence/operator_console.py)
-- [migrations/versions/0030_duplicate_bin_item_fields.py](/home/harish/projects/media-manager/migrations/versions/0030_duplicate_bin_item_fields.py)
-- [migrations/versions/0031_duplicate_bin_item_backfill.py](/home/harish/projects/media-manager/migrations/versions/0031_duplicate_bin_item_backfill.py)
-- [media_manager/tests/test_phase3_duplicate_reclaim.py](/home/harish/projects/media-manager/media_manager/tests/test_phase3_duplicate_reclaim.py)
-- [media_manager/tests/test_migration_duplicate_bin_item_backfill.py](/home/harish/projects/media-manager/media_manager/tests/test_migration_duplicate_bin_item_backfill.py)
-- [media_manager/tests/test_operator_console_duplicates.py](/home/harish/projects/media-manager/media_manager/tests/test_operator_console_duplicates.py)
+- `media_manager/app/persistence/models.py`
+- `media_manager/app/persistence/phase3_actions.py`
+- `media_manager/app/persistence/apply.py`
+- `media_manager/app/persistence/operator_console.py`
+- `migrations/versions/0030_duplicate_bin_item_fields.py`
+- `migrations/versions/0031_duplicate_bin_item_backfill.py`
+- `media_manager/tests/test_phase3_duplicate_reclaim.py`
+- `media_manager/tests/test_migration_duplicate_bin_item_backfill.py`
+- `media_manager/tests/test_operator_console_duplicates.py`
 
 ## A. Current Post-Phase-4 Authority Inventory
 

--- a/documentation/getting-started/quickstart.md
+++ b/documentation/getting-started/quickstart.md
@@ -20,7 +20,13 @@ TEST_DATABASE_URL='postgresql+psycopg://user:password@localhost:5432/media_manag
 `media-manager-api` loads repo `.env` automatically.  
 For all variables and defaults, see [Environment Variables](../reference/environment-variables.md).
 
-## 2. Select Input Path
+## 2. Initialize The Database Schema
+
+```bash
+alembic upgrade head
+```
+
+## 3. Select Input Path
 
 Choose a file or directory with media files.
 
@@ -30,13 +36,13 @@ Example:
 INPUT_PATH=/path/to/media
 ```
 
-## 3. Start The API
+## 4. Start The API
 
 ```bash
 media-manager-api
 ```
 
-## 4. Plan
+## 5. Plan
 
 ```bash
 curl -X POST http://127.0.0.1:8000/api/plan \
@@ -52,7 +58,7 @@ Expected response:
 
 Save the emitted `run_id` for apply.
 
-## 5. Apply Planned Actions
+## 6. Apply Planned Actions
 
 ```bash
 curl -X POST http://127.0.0.1:8000/api/apply \
@@ -60,7 +66,7 @@ curl -X POST http://127.0.0.1:8000/api/apply \
   -d '{"run_id":"<RUN_ID>","collision_mode":"rename"}'
 ```
 
-## 6. Verify
+## 7. Verify
 
 - Filesystem changes should match planned actions.
 - API response should show no unexpected errors.

--- a/documentation/getting-started/quickstart.md
+++ b/documentation/getting-started/quickstart.md
@@ -22,6 +22,14 @@ For all variables and defaults, see [Environment Variables](../reference/environ
 
 ## 2. Initialize The Database Schema
 
+First, ensure the PostgreSQL database referenced by `DATABASE_URL` exists. Create it if needed:
+
+```bash
+createdb media_manager
+```
+
+Then run the migrations:
+
 ```bash
 alembic upgrade head
 ```

--- a/media_manager/tests/test_operator_console_canonical_gallery.py
+++ b/media_manager/tests/test_operator_console_canonical_gallery.py
@@ -722,8 +722,8 @@ def test_resolve_media_source_supports_windows_path_wsl_fallback(
     now = datetime(2026, 3, 2, 16, 0, tzinfo=UTC)
     content_id = UUID("90000000-0000-0000-0000-000000000001")
     file_instance_id = UUID("91000000-0000-0000-0000-000000000001")
-    windows_path = r"C:\Users\micro\Documents\Better Up\Media-Manager-Test\PIC\gallery_frame.jpg"
-    mapped_path = tmp_path / "mnt" / "c" / "Users" / "micro" / "Documents" / "Better Up" / "Media-Manager-Test" / "PIC" / "gallery_frame.jpg"
+    windows_path = r"C:\Users\example\Documents\MediaManagerTest\PIC\gallery_frame.jpg"
+    mapped_path = tmp_path / "mnt" / "c" / "Users" / "example" / "Documents" / "MediaManagerTest" / "PIC" / "gallery_frame.jpg"
     mapped_path.parent.mkdir(parents=True, exist_ok=True)
     mapped_path.write_bytes(b"img")
 

--- a/media_manager/tests/test_operator_console_duplicates.py
+++ b/media_manager/tests/test_operator_console_duplicates.py
@@ -554,8 +554,8 @@ def test_resolve_thumbnail_source_supports_windows_path_wsl_fallback(
     now = datetime(2026, 3, 1, 16, 0, tzinfo=UTC)
     content_id = UUID("12121212-3434-5656-7878-909090909090")
     file_instance_id = UUID("21212121-4343-6565-8787-101010101010")
-    windows_style_path = r"C:\Users\micro\Documents\Better Up\Media-Manager-Test\PIC\harishkamathuk - Personal Chapters — 2021-09-13_105647.JPG"
-    mapped_path = tmp_path / "mnt" / "c" / "Users" / "micro" / "Documents" / "Better Up" / "Media-Manager-Test" / "PIC" / "harishkamathuk - Personal Chapters — 2021-09-13_105647.JPG"
+    windows_style_path = r"C:\Users\example\Documents\MediaManagerTest\PIC\sample-album-2021-09-13_105647.JPG"
+    mapped_path = tmp_path / "mnt" / "c" / "Users" / "example" / "Documents" / "MediaManagerTest" / "PIC" / "sample-album-2021-09-13_105647.JPG"
     mapped_path.parent.mkdir(parents=True, exist_ok=True)
     mapped_path.write_bytes(b"jpeg-data")
 

--- a/media_manager/tests/test_service_layer_operations.py
+++ b/media_manager/tests/test_service_layer_operations.py
@@ -857,8 +857,8 @@ def test_ingest_accepts_wrapped_quotes_path(tmp_path: Path, monkeypatch: pytest.
 
 
 def test_ingest_accepts_mnt_uppercase_drive_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    canonical = Path("/mnt/c/Users/micro/Documents/Media-Manager-Test")
-    uppercase = Path("/mnt/C/Users/micro/Documents/Media-Manager-Test")
+    canonical = Path("/mnt/c/Users/example/Documents/MediaManagerTest")
+    uppercase = Path("/mnt/C/Users/example/Documents/MediaManagerTest")
 
     def _fake_exists(self: Path) -> bool:
         return str(self) == str(canonical)
@@ -885,8 +885,8 @@ def test_ingest_accepts_mnt_uppercase_drive_path(monkeypatch: pytest.MonkeyPatch
 
 
 def test_ingest_accepts_windows_drive_path_via_wsl_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
-    mapped = Path("/mnt/c/Users/micro/Documents/Media-Manager-Test")
-    windows = "C:\\Users\\micro\\Documents\\Media-Manager-Test"
+    mapped = Path("/mnt/c/Users/example/Documents/MediaManagerTest")
+    windows = "C:\\Users\\example\\Documents\\MediaManagerTest"
 
     def _fake_exists(self: Path) -> bool:
         return str(self) == str(mapped)
@@ -968,8 +968,8 @@ def test_plan_accepts_wrapped_quotes_path(tmp_path: Path, monkeypatch: pytest.Mo
 
 
 def test_media_file_validate_accepts_windows_drive_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    mapped = Path("/mnt/c/Users/micro/Documents/Media-Manager-Test")
-    windows = "C:\\Users\\micro\\Documents\\Media-Manager-Test"
+    mapped = Path("/mnt/c/Users/example/Documents/MediaManagerTest")
+    windows = "C:\\Users\\example\\Documents\\MediaManagerTest"
 
     def _fake_exists(self: Path) -> bool:
         return str(self) == str(mapped)


### PR DESCRIPTION
## Summary

This PR makes a first baseline public-readiness hygiene pass on the repository without changing architecture, runtime behavior, or licensing direction.

It focuses on reducing obvious local/private exposure in tracked content, tightening local-only ignore rules, and making the documented setup path clearer for an external reader.

## Why this change

The repository is moving toward eventual public release, but it still had a few rough edges that would make a first public view feel too internal:

- some docs still referenced local absolute filesystem paths
- setup docs did not clearly include database migration initialization before runtime
- a few tracked test fixture placeholders still looked like private local residue
- local env/tooling/build outputs needed a slightly tighter ignore baseline

This PR addresses those issues as a narrow hygiene slice, not as a final release-prep step.

## What changed

- tightened `.gitignore` for local env variants, local tooling/cache output, coverage artifacts, and frontend build output
- updated `README.md` with clearer public-facing setup guidance
- clarified that `.env` is local-only and should be created from the committed sample
- added the missing `alembic upgrade head` step to the documented setup flow
- updated quickstart docs to match that setup sequence
- sanitized local absolute `/home/...` file references from architecture docs
- replaced a few personal/company-flavored Windows test fixture path placeholders with generic examples

## What did not change

- did not change the existing license
- did not rewrite git history
- did not add `CONTRIBUTING.md`, `SECURITY.md`, issue templates, or CI changes
- did not introduce new features or refactor unrelated code
- did not attempt a full historical secret audit in this slice

## Risks / limitations

- this is a baseline hygiene pass, not the final public-release step
- license finalization is intentionally deferred
- historical secret/history review is intentionally deferred
- clean-room setup validation is intentionally deferred
- full local test execution was not completed in this pass because the current checkout did not have `pytest` available in `.venv`

## Manual verification

- review `git diff develop...chore/public-readiness-baseline`
- confirm `operator_console/gui_app/package-lock.json` is not included in the PR
- confirm `git ls-files .env` returns nothing
- grep for obvious private path residue:
  - `/home/harish/projects/media-manager`
  - `Better Up`
  - `Personal Chapters`
- on a prepared local env:
  - `source .venv/bin/activate`
  - `pip install -e ".[dev]"`
  - `cp .env.sample .env`
  - fill in local PostgreSQL and storage-path values
  - `alembic upgrade head`
  - `./.venv/bin/python -m pytest`

## Follow-up slices

- decide final public license direction for the repository
- run a broader historical secret audit across branches/tags/remotes
- perform a clean-room setup validation from README on a fresh machine/container
- do a final public-release polish pass on docs metadata, repository settings, and external-facing wording

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added early-stage status messaging and clarified contribution guidance.
  * Revised quickstart and README to require initializing the database schema before starting the API and updated environment setup guidance.
  * Standardized internal implementation reference formatting across architecture docs.

* **Chores**
  * Updated ignore rules to exclude build output, local env files, and local tool cache while keeping the example env file tracked.

* **Tests**
  * Updated test fixtures to use generic example Windows/WSL paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->