### PR TITLE
feat: add narrow app_settings pilot foundation

### DIFF
--- a/media_manager/app/core/errors.py
+++ b/media_manager/app/core/errors.py
@@ -104,6 +104,14 @@ class PolicySettingsVersionConflictError(MediaManagerError):
     """Raised when a policy update is based on a stale version."""
 
 
+class AppSettingsValidationError(MediaManagerError):
+    """Raised when app settings payload fails deterministic validation."""
+
+
+class AppSettingsVersionConflictError(MediaManagerError):
+    """Raised when an app setting update is based on a stale version."""
+
+
 class OwnerContextOverrideRequiredError(MediaManagerError):
     """Raised when an ingest/plan request conflicts with stored owner/context values."""
 

--- a/media_manager/app/persistence/app_settings.py
+++ b/media_manager/app/persistence/app_settings.py
@@ -1,0 +1,588 @@
+"""Durable app settings foundation and narrow runtime dual-read helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from sqlalchemy import update
+from sqlalchemy.orm import Session, sessionmaker
+
+from media_manager.app.canonical.factory import resolve_default_policy_name
+from media_manager.app.core.config import REQUIRED_METADATA_CODES, load_environment, resolve_storage_roots
+from media_manager.app.core.errors import AppSettingsValidationError, AppSettingsVersionConflictError
+from media_manager.app.persistence.base import transactional_session
+from media_manager.app.persistence.models import AppSetting, AppSettingHistory
+
+ValueType = Literal["bool", "string", "string_list", "enum", "path", "float", "int"]
+
+CANONICAL_POLICY_VALUES = frozenset({"FIRST_SEEN", "PREFER_ROOT", "EXIF_FILENAME_FALLBACK", "SHORTEST_PATH"})
+BENCHMARK_WORKER_MODE_VALUES = frozenset({"forever", "once"})
+DB_RESET_CHALLENGE_WORD_DEFAULT = "media-manager"
+TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
+RUNTIME_DUAL_READ_KEYS = frozenset(
+    {
+        "directory_picker_enabled",
+        "directory_picker_roots",
+        "video_thumbnails_enabled",
+        "video_thumbnail_cache_dir",
+        "canonical_read_cache_enabled",
+        "canonical_read_cache_ttl_seconds",
+        "metadata_upsert_batch_size",
+        "benchmark_worker_mode",
+        "benchmark_poll_interval_seconds",
+    }
+)
+
+
+@dataclass(frozen=True)
+class AppSettingDefinition:
+    key: str
+    env_var: str
+    value_type: ValueType
+    category: str
+    is_sensitive: bool = False
+
+
+@dataclass(frozen=True)
+class AppSettingSnapshot:
+    key: str
+    value: bool | str | float | int | list[str]
+    value_json: dict[str, object]
+    value_type: str
+    category: str
+    scope: str
+    is_sensitive: bool
+    updated_by: str
+    updated_at: datetime
+    version: int
+    source: str
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    inserted_keys: tuple[str, ...]
+    skipped_keys: tuple[str, ...]
+
+
+_CATALOG: dict[str, AppSettingDefinition] = {
+    "required_metadata_codes": AppSettingDefinition(
+        key="required_metadata_codes",
+        env_var="MEDIA_REQUIRED_CODES",
+        value_type="string_list",
+        category="policy",
+    ),
+    "canonical_policy": AppSettingDefinition(
+        key="canonical_policy",
+        env_var="MEDIA_CANONICAL_POLICY",
+        value_type="enum",
+        category="policy",
+    ),
+    "preferred_roots": AppSettingDefinition(
+        key="preferred_roots",
+        env_var="MEDIA_PREFERRED_ROOTS",
+        value_type="string_list",
+        category="policy",
+    ),
+    "tag_normalization_remove_punctuation": AppSettingDefinition(
+        key="tag_normalization_remove_punctuation",
+        env_var="MEDIA_MANAGER_TAG_NORMALIZATION_REMOVE_PUNCTUATION",
+        value_type="bool",
+        category="policy",
+    ),
+    "canonical_storage_path": AppSettingDefinition(
+        key="canonical_storage_path",
+        env_var="MEDIA_CANONICAL_STORAGE_PATH",
+        value_type="path",
+        category="storage",
+    ),
+    "duplicate_storage_path": AppSettingDefinition(
+        key="duplicate_storage_path",
+        env_var="MEDIA_DUPLICATE_STORAGE_PATH",
+        value_type="path",
+        category="storage",
+    ),
+    "video_thumbnail_cache_dir": AppSettingDefinition(
+        key="video_thumbnail_cache_dir",
+        env_var="MEDIA_MANAGER_VIDEO_THUMBNAIL_CACHE_DIR",
+        value_type="path",
+        category="storage",
+    ),
+    "directory_picker_enabled": AppSettingDefinition(
+        key="directory_picker_enabled",
+        env_var="MEDIA_MANAGER_DIRECTORY_PICKER_ENABLED",
+        value_type="bool",
+        category="ui",
+    ),
+    "directory_picker_roots": AppSettingDefinition(
+        key="directory_picker_roots",
+        env_var="MEDIA_MANAGER_DIRECTORY_PICKER_ROOTS",
+        value_type="string_list",
+        category="ui",
+    ),
+    "video_thumbnails_enabled": AppSettingDefinition(
+        key="video_thumbnails_enabled",
+        env_var="MEDIA_MANAGER_VIDEO_THUMBNAILS_ENABLED",
+        value_type="bool",
+        category="ui",
+    ),
+    "benchmarks_enabled": AppSettingDefinition(
+        key="benchmarks_enabled",
+        env_var="MEDIA_MANAGER_BENCHMARKS_ENABLED",
+        value_type="bool",
+        category="ui",
+    ),
+    "allow_planner_mv_reads": AppSettingDefinition(
+        key="allow_planner_mv_reads",
+        env_var="MEDIA_MANAGER_ALLOW_PLANNER_MV_READS",
+        value_type="bool",
+        category="ui",
+    ),
+    "canonical_read_cache_enabled": AppSettingDefinition(
+        key="canonical_read_cache_enabled",
+        env_var="CANONICAL_READ_CACHE_ENABLED",
+        value_type="bool",
+        category="performance",
+    ),
+    "canonical_read_cache_ttl_seconds": AppSettingDefinition(
+        key="canonical_read_cache_ttl_seconds",
+        env_var="CANONICAL_READ_CACHE_TTL_SECONDS",
+        value_type="float",
+        category="performance",
+    ),
+    "metadata_upsert_batch_size": AppSettingDefinition(
+        key="metadata_upsert_batch_size",
+        env_var="METADATA_UPSERT_BATCH_SIZE",
+        value_type="int",
+        category="performance",
+    ),
+    "benchmark_max_items": AppSettingDefinition(
+        key="benchmark_max_items",
+        env_var="MEDIA_MANAGER_BENCHMARK_MAX_ITEMS",
+        value_type="int",
+        category="performance",
+    ),
+    "benchmark_poll_interval_seconds": AppSettingDefinition(
+        key="benchmark_poll_interval_seconds",
+        env_var="MEDIA_MANAGER_BENCHMARK_POLL_INTERVAL_SECONDS",
+        value_type="float",
+        category="performance",
+    ),
+    "benchmark_stale_after_seconds": AppSettingDefinition(
+        key="benchmark_stale_after_seconds",
+        env_var="MEDIA_MANAGER_BENCHMARK_STALE_AFTER_SECONDS",
+        value_type="float",
+        category="performance",
+    ),
+    "benchmark_worker_mode": AppSettingDefinition(
+        key="benchmark_worker_mode",
+        env_var="MEDIA_MANAGER_BENCHMARK_WORKER_MODE",
+        value_type="enum",
+        category="performance",
+    ),
+    "db_reset_include_dynamic": AppSettingDefinition(
+        key="db_reset_include_dynamic",
+        env_var="MEDIA_MANAGER_DB_RESET_INCLUDE_DYNAMIC",
+        value_type="bool",
+        category="admin_safety",
+    ),
+    "db_reset_challenge_word": AppSettingDefinition(
+        key="db_reset_challenge_word",
+        env_var="MEDIA_MANAGER_DB_RESET_CHALLENGE_WORD",
+        value_type="string",
+        category="admin_safety",
+        is_sensitive=True,
+    ),
+}
+
+
+def _truthy(raw: str) -> bool:
+    return raw.strip().lower() in TRUTHY_VALUES
+
+
+def _split_csv_preserve_order(raw: str) -> list[str]:
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _normalize_string_list(value: list[str] | tuple[str, ...]) -> list[str]:
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise AppSettingsValidationError("string_list settings must contain strings only.")
+        cleaned = item.strip()
+        if cleaned:
+            normalized.append(cleaned)
+    return normalized
+
+
+def _normalize_path_string(raw: str, *, field_name: str) -> str:
+    value = str(raw).strip()
+    if not value:
+        raise AppSettingsValidationError(f"{field_name} must not be empty.")
+    expanded = str(Path(value).expanduser())
+    if not Path(expanded).is_absolute():
+        raise AppSettingsValidationError(f"{field_name} must be an absolute path.")
+    return expanded
+
+
+class AppSettingsService:
+    def __init__(self, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory = session_factory
+
+    @staticmethod
+    def definition_for(key: str) -> AppSettingDefinition:
+        definition = _CATALOG.get(key)
+        if definition is None:
+            raise AppSettingsValidationError(f"Unknown app setting key: {key}")
+        return definition
+
+    def get_setting(self, key: str, *, session: Session | None = None) -> AppSettingSnapshot | None:
+        definition = self.definition_for(key)
+        if session is not None:
+            row = session.get(AppSetting, key)
+            return None if row is None else self._snapshot_from_row(row, definition)
+        with self._session_factory() as local_session:
+            row = local_session.get(AppSetting, key)
+            return None if row is None else self._snapshot_from_row(row, definition)
+
+    def set_value(
+        self,
+        key: str,
+        value: object,
+        *,
+        updated_by: str,
+        source: str,
+        expected_version: int = 0,
+        reason: str | None = None,
+    ) -> AppSettingSnapshot:
+        definition = self.definition_for(key)
+        normalized = self._normalize_value(definition, value)
+        payload = {"value": normalized}
+
+        with transactional_session(self._session_factory) as session:
+            existing = session.get(AppSetting, key)
+            if existing is None:
+                if int(expected_version) != 0:
+                    raise AppSettingsVersionConflictError(
+                        f"App setting version conflict for {key}: expected 0, current missing."
+                    )
+                row = AppSetting(
+                    key=key,
+                    value_json=payload,
+                    value_type=definition.value_type,
+                    category=definition.category,
+                    scope="global",
+                    is_sensitive=definition.is_sensitive,
+                    updated_by=updated_by,
+                    source=source,
+                )
+                session.add(row)
+                session.flush()
+                session.add(
+                    AppSettingHistory(
+                        key=key,
+                        old_value_json=None,
+                        new_value_json=payload,
+                        changed_by=updated_by,
+                        reason=reason,
+                        source=source,
+                    )
+                )
+                session.flush()
+                return self._snapshot_from_row(row, definition)
+
+            old_value_json = dict(existing.value_json)
+            stmt = (
+                update(AppSetting)
+                .where(AppSetting.key == key, AppSetting.version == int(expected_version))
+                .values(
+                    value_json=payload,
+                    value_type=definition.value_type,
+                    category=definition.category,
+                    scope="global",
+                    is_sensitive=definition.is_sensitive,
+                    updated_by=updated_by,
+                    updated_at=datetime.now(timezone.utc),
+                    source=source,
+                    version=AppSetting.version + 1,
+                )
+            )
+            result = session.execute(stmt)
+            if result.rowcount != 1:
+                raise AppSettingsVersionConflictError(
+                    f"App setting version conflict for {key}: expected {expected_version}, current {existing.version}."
+                )
+            session.add(
+                AppSettingHistory(
+                    key=key,
+                    old_value_json=old_value_json,
+                    new_value_json=payload,
+                    changed_by=updated_by,
+                    reason=reason,
+                    source=source,
+                )
+            )
+            session.flush()
+            updated = session.get(AppSetting, key)
+            if updated is None:  # pragma: no cover - defensive integrity guard
+                raise RuntimeError(f"Updated app setting disappeared unexpectedly: {key}")
+            return self._snapshot_from_row(updated, definition)
+
+    def bootstrap_from_env(self) -> BootstrapResult:
+        inserted: list[str] = []
+        skipped: list[str] = []
+        load_environment()
+
+        with transactional_session(self._session_factory) as session:
+            for key, definition in _CATALOG.items():
+                if session.get(AppSetting, key) is not None:
+                    skipped.append(key)
+                    continue
+                value = self._parse_env_value(definition, strict=True)
+                payload = {"value": value}
+                session.add(
+                    AppSetting(
+                        key=key,
+                        value_json=payload,
+                        value_type=definition.value_type,
+                        category=definition.category,
+                        scope="global",
+                        is_sensitive=definition.is_sensitive,
+                        updated_by="system:bootstrap_env",
+                        source="bootstrap_env",
+                    )
+                )
+                session.add(
+                    AppSettingHistory(
+                        key=key,
+                        old_value_json=None,
+                        new_value_json=payload,
+                        changed_by="system:bootstrap_env",
+                        reason=None,
+                        source="bootstrap_env",
+                    )
+                )
+                inserted.append(key)
+
+        return BootstrapResult(inserted_keys=tuple(inserted), skipped_keys=tuple(skipped))
+
+    def resolve_runtime_value(
+        self,
+        key: str,
+        *,
+        logger: logging.Logger | None = None,
+        session: Session | None = None,
+    ) -> bool | str | float | int | list[str]:
+        if key not in RUNTIME_DUAL_READ_KEYS:
+            raise AppSettingsValidationError(f"{key} is not enabled for runtime dual-read in this slice.")
+        definition = self.definition_for(key)
+        snapshot = self.get_setting(key, session=session)
+        if snapshot is not None:
+            return snapshot.value
+        if logger is not None:
+            logger.warning(
+                "App setting missing in DB; using environment fallback",
+                extra={"app_setting_key": key, "fallback_source": "env"},
+            )
+        return self._parse_env_value(definition, strict=False)
+
+    def _snapshot_from_row(self, row: AppSetting, definition: AppSettingDefinition) -> AppSettingSnapshot:
+        return AppSettingSnapshot(
+            key=row.key,
+            value=self._normalize_value(definition, row.value_json.get("value")),
+            value_json=row.value_json,
+            value_type=row.value_type,
+            category=row.category,
+            scope=row.scope,
+            is_sensitive=bool(row.is_sensitive),
+            updated_by=row.updated_by,
+            updated_at=row.updated_at,
+            version=int(row.version),
+            source=row.source,
+        )
+
+    def _normalize_value(self, definition: AppSettingDefinition, value: object) -> bool | str | float | int | list[str]:
+        key = definition.key
+        if definition.value_type == "bool":
+            if not isinstance(value, bool):
+                raise AppSettingsValidationError(f"{key} must be a boolean.")
+            return value
+        if definition.value_type == "string":
+            normalized = str(value).strip()
+            if not normalized:
+                raise AppSettingsValidationError(f"{key} must not be empty.")
+            return normalized
+        if definition.value_type == "string_list":
+            if not isinstance(value, (list, tuple)):
+                raise AppSettingsValidationError(f"{key} must be a list of strings.")
+            if key == "required_metadata_codes":
+                return [item.upper() for item in _normalize_string_list(list(value))]
+            return _normalize_string_list(list(value))
+        if definition.value_type == "path":
+            return _normalize_path_string(str(value), field_name=key)
+        if definition.value_type == "float":
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError) as exc:
+                raise AppSettingsValidationError(f"{key} must be a float.") from exc
+            if key in {
+                "canonical_read_cache_ttl_seconds",
+                "benchmark_poll_interval_seconds",
+                "benchmark_stale_after_seconds",
+            } and parsed <= 0:
+                raise AppSettingsValidationError(f"{key} must be > 0.")
+            return float(parsed)
+        if definition.value_type == "int":
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError) as exc:
+                raise AppSettingsValidationError(f"{key} must be an integer.") from exc
+            if key == "metadata_upsert_batch_size":
+                return min(max(parsed, 1), 50_000)
+            if key in {"benchmark_max_items"} and parsed <= 0:
+                raise AppSettingsValidationError(f"{key} must be > 0.")
+            return int(parsed)
+        if definition.value_type == "enum":
+            normalized = str(value).strip()
+            if key == "canonical_policy":
+                normalized = normalized.upper()
+                if normalized not in CANONICAL_POLICY_VALUES:
+                    raise AppSettingsValidationError(
+                        "canonical_policy must be one of FIRST_SEEN, PREFER_ROOT, EXIF_FILENAME_FALLBACK, SHORTEST_PATH."
+                    )
+                return normalized
+            if key == "benchmark_worker_mode":
+                normalized = normalized.lower()
+                if normalized not in BENCHMARK_WORKER_MODE_VALUES:
+                    raise AppSettingsValidationError("benchmark_worker_mode must be forever or once.")
+                return normalized
+        raise AppSettingsValidationError(f"Unsupported app setting type for {key}: {definition.value_type}")
+
+    def _parse_env_value(self, definition: AppSettingDefinition, *, strict: bool) -> bool | str | float | int | list[str]:
+        load_environment()
+        key = definition.key
+        env_name = definition.env_var
+        raw = os.getenv(env_name)
+        cleaned = (raw or "").strip()
+
+        if key == "required_metadata_codes":
+            values = [item.upper() for item in _split_csv_preserve_order(cleaned)] if cleaned else list(REQUIRED_METADATA_CODES)
+            return values or list(REQUIRED_METADATA_CODES)
+        if key == "canonical_policy":
+            return self._normalize_value(definition, resolve_default_policy_name())
+        if key in {"preferred_roots", "directory_picker_roots"}:
+            return _split_csv_preserve_order(cleaned) if cleaned else []
+        if key == "tag_normalization_remove_punctuation":
+            return _truthy(cleaned or "0")
+        if key == "canonical_storage_path":
+            return str(resolve_storage_roots().canonical_root)
+        if key == "duplicate_storage_path":
+            return str(resolve_storage_roots().duplicate_root)
+        if key == "video_thumbnail_cache_dir":
+            path_value = cleaned if cleaned else str(Path(tempfile.gettempdir()) / "media-manager" / "video-thumbnails")
+            return _normalize_path_string(path_value, field_name=key)
+        if key in {
+            "directory_picker_enabled",
+            "video_thumbnails_enabled",
+            "benchmarks_enabled",
+            "allow_planner_mv_reads",
+            "canonical_read_cache_enabled",
+            "db_reset_include_dynamic",
+        }:
+            default = "false"
+            return _truthy(cleaned or default)
+        if key == "db_reset_challenge_word":
+            return cleaned or DB_RESET_CHALLENGE_WORD_DEFAULT
+        if key == "canonical_read_cache_ttl_seconds":
+            return self._parse_float_env(key, cleaned, default=30.0, strict=strict, positive=True, fallback_on_invalid=30.0)
+        if key == "metadata_upsert_batch_size":
+            return self._parse_int_env(key, cleaned, default=1000, strict=strict, clamp=(1, 50_000), positive=False)
+        if key == "benchmark_max_items":
+            return self._parse_int_env(key, cleaned, default=10_000, strict=strict, clamp=None, positive=True)
+        if key == "benchmark_poll_interval_seconds":
+            return self._parse_float_env(key, cleaned, default=2.0, strict=strict, positive=strict, fallback_on_invalid=None)
+        if key == "benchmark_stale_after_seconds":
+            if strict:
+                return self._parse_float_env(key, cleaned, default=900.0, strict=True, positive=True, fallback_on_invalid=None)
+            value = self._parse_float_env(key, cleaned, default=900.0, strict=False, positive=False, fallback_on_invalid=None)
+            return max(1.0, value)
+        if key == "benchmark_worker_mode":
+            if strict:
+                return self._normalize_value(definition, cleaned or "forever")
+            normalized = (cleaned or "forever").strip().lower()
+            return "once" if normalized == "once" else "forever"
+        raise AppSettingsValidationError(f"No env parser configured for {key}.")
+
+    def _parse_float_env(
+        self,
+        key: str,
+        raw: str,
+        *,
+        default: float,
+        strict: bool,
+        positive: bool,
+        fallback_on_invalid: float | None,
+    ) -> float:
+        if not raw:
+            return float(default)
+        try:
+            value = float(raw)
+        except ValueError as exc:
+            if strict:
+                raise AppSettingsValidationError(f"{key} must be a valid float.") from exc
+            if fallback_on_invalid is not None:
+                return float(fallback_on_invalid)
+            raise
+        if positive and value <= 0:
+            if strict:
+                raise AppSettingsValidationError(f"{key} must be > 0.")
+            if fallback_on_invalid is not None:
+                return float(fallback_on_invalid)
+        return float(value)
+
+    def _parse_int_env(
+        self,
+        key: str,
+        raw: str,
+        *,
+        default: int,
+        strict: bool,
+        clamp: tuple[int, int] | None,
+        positive: bool,
+    ) -> int:
+        if not raw:
+            value = int(default)
+        else:
+            try:
+                value = int(raw)
+            except ValueError as exc:
+                if strict:
+                    raise AppSettingsValidationError(f"{key} must be a valid integer.") from exc
+                return int(default)
+        if positive and value <= 0:
+            raise AppSettingsValidationError(f"{key} must be > 0.")
+        if clamp is not None:
+            low, high = clamp
+            value = min(max(value, low), high)
+        return int(value)
+
+
+def bootstrap_app_settings_from_env(session_factory: sessionmaker[Session]) -> BootstrapResult:
+    return AppSettingsService(session_factory).bootstrap_from_env()
+
+
+def render_bootstrap_result(result: BootstrapResult) -> str:
+    return json.dumps(
+        {
+            "inserted_keys": list(result.inserted_keys),
+            "skipped_keys": list(result.skipped_keys),
+        },
+        indent=2,
+        sort_keys=False,
+    )

--- a/media_manager/app/persistence/app_settings.py
+++ b/media_manager/app/persistence/app_settings.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy import update
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -229,6 +230,20 @@ def _normalize_path_string(raw: str, *, field_name: str) -> str:
     return expanded
 
 
+def _redact_history_payload(definition: AppSettingDefinition, payload: dict[str, object] | None) -> dict[str, object] | None:
+    if payload is None:
+        return None
+    if not definition.is_sensitive:
+        return dict(payload)
+    return {"value": "<REDACTED>"}
+
+
+def _raise_concurrent_create_conflict(key: str) -> None:
+    raise AppSettingsVersionConflictError(
+        f"App setting version conflict for {key}: expected 0, current created concurrently."
+    )
+
+
 class AppSettingsService:
     def __init__(self, session_factory: sessionmaker[Session]) -> None:
         self._session_factory = session_factory
@@ -281,12 +296,15 @@ class AppSettingsService:
                     source=source,
                 )
                 session.add(row)
-                session.flush()
+                try:
+                    session.flush()
+                except IntegrityError as exc:
+                    _raise_concurrent_create_conflict(key)
                 session.add(
                     AppSettingHistory(
                         key=key,
                         old_value_json=None,
-                        new_value_json=payload,
+                        new_value_json=_redact_history_payload(definition, payload),
                         changed_by=updated_by,
                         reason=reason,
                         source=source,
@@ -319,8 +337,8 @@ class AppSettingsService:
             session.add(
                 AppSettingHistory(
                     key=key,
-                    old_value_json=old_value_json,
-                    new_value_json=payload,
+                    old_value_json=_redact_history_payload(definition, old_value_json),
+                    new_value_json=_redact_history_payload(definition, payload),
                     changed_by=updated_by,
                     reason=reason,
                     source=source,
@@ -344,28 +362,35 @@ class AppSettingsService:
                     continue
                 value = self._parse_env_value(definition, strict=True)
                 payload = {"value": value}
-                session.add(
-                    AppSetting(
-                        key=key,
-                        value_json=payload,
-                        value_type=definition.value_type,
-                        category=definition.category,
-                        scope="global",
-                        is_sensitive=definition.is_sensitive,
-                        updated_by="system:bootstrap_env",
-                        source="bootstrap_env",
-                    )
-                )
-                session.add(
-                    AppSettingHistory(
-                        key=key,
-                        old_value_json=None,
-                        new_value_json=payload,
-                        changed_by="system:bootstrap_env",
-                        reason=None,
-                        source="bootstrap_env",
-                    )
-                )
+                try:
+                    with session.begin_nested():
+                        session.add(
+                            AppSetting(
+                                key=key,
+                                value_json=payload,
+                                value_type=definition.value_type,
+                                category=definition.category,
+                                scope="global",
+                                is_sensitive=definition.is_sensitive,
+                                updated_by="system:bootstrap_env",
+                                source="bootstrap_env",
+                            )
+                        )
+                        session.flush()
+                        session.add(
+                            AppSettingHistory(
+                                key=key,
+                                old_value_json=None,
+                                new_value_json=_redact_history_payload(definition, payload),
+                                changed_by="system:bootstrap_env",
+                                reason=None,
+                                source="bootstrap_env",
+                            )
+                        )
+                        session.flush()
+                except IntegrityError:
+                    skipped.append(key)
+                    continue
                 inserted.append(key)
 
         return BootstrapResult(inserted_keys=tuple(inserted), skipped_keys=tuple(skipped))
@@ -425,6 +450,8 @@ class AppSettingsService:
         if definition.value_type == "path":
             return _normalize_path_string(str(value), field_name=key)
         if definition.value_type == "float":
+            if isinstance(value, bool):
+                raise AppSettingsValidationError(f"{key} must be a float.")
             try:
                 parsed = float(value)
             except (TypeError, ValueError) as exc:
@@ -437,6 +464,8 @@ class AppSettingsService:
                 raise AppSettingsValidationError(f"{key} must be > 0.")
             return float(parsed)
         if definition.value_type == "int":
+            if isinstance(value, bool):
+                raise AppSettingsValidationError(f"{key} must be an integer.")
             try:
                 parsed = int(value)
             except (TypeError, ValueError) as exc:

--- a/media_manager/app/persistence/app_settings.py
+++ b/media_manager/app/persistence/app_settings.py
@@ -28,8 +28,6 @@ DB_RESET_CHALLENGE_WORD_DEFAULT = "media-manager"
 TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 RUNTIME_DUAL_READ_KEYS = frozenset(
     {
-        "directory_picker_enabled",
-        "directory_picker_roots",
         "video_thumbnails_enabled",
         "video_thumbnail_cache_dir",
         "canonical_read_cache_enabled",

--- a/media_manager/app/persistence/app_settings_bootstrap.py
+++ b/media_manager/app/persistence/app_settings_bootstrap.py
@@ -1,0 +1,20 @@
+"""Bootstrap current env-backed settings into durable app_settings."""
+
+from __future__ import annotations
+
+from media_manager.app.persistence.app_settings import bootstrap_app_settings_from_env, render_bootstrap_result
+from media_manager.app.persistence.base import create_db_engine, create_session_factory
+
+
+def main() -> None:
+    engine = create_db_engine()
+    session_factory = create_session_factory(engine)
+    try:
+        result = bootstrap_app_settings_from_env(session_factory)
+        print(render_bootstrap_result(result))
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    main()

--- a/media_manager/app/persistence/materialized_reads.py
+++ b/media_manager/app/persistence/materialized_reads.py
@@ -23,8 +23,10 @@ from sqlalchemy import text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
+from media_manager.app.core.logging_config import get_logger
 from media_manager.app.core.ttl_cache import TTLCache
 from media_manager.app.observability import record_canonical_read_cache_disabled, record_canonical_read_cache_metrics
+from media_manager.app.persistence.app_settings import AppSettingsService
 
 
 @dataclass(frozen=True)
@@ -97,12 +99,22 @@ SELECT
 FROM mv_canonical_metadata
 """
 
-
-def _env_cache_enabled() -> bool:
-    return os.getenv("CANONICAL_READ_CACHE_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+LOGGER = get_logger(__name__)
 
 
-def _env_cache_ttl() -> float:
+def _env_cache_enabled(session: Session | None = None) -> bool:
+    if session is None:
+        return os.getenv("CANONICAL_READ_CACHE_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+    service = AppSettingsService(sessionmaker(bind=session.get_bind(), autoflush=False, autocommit=False, expire_on_commit=False))
+    return bool(service.resolve_runtime_value("canonical_read_cache_enabled", logger=LOGGER, session=session))
+
+
+def _env_cache_ttl(session: Session | None = None) -> float:
+    if session is not None:
+        service = AppSettingsService(
+            sessionmaker(bind=session.get_bind(), autoflush=False, autocommit=False, expire_on_commit=False)
+        )
+        return float(service.resolve_runtime_value("canonical_read_cache_ttl_seconds", logger=LOGGER, session=session))
     raw = os.getenv("CANONICAL_READ_CACHE_TTL_SECONDS", "30")
     try:
         value = float(raw)
@@ -115,6 +127,13 @@ def _env_cache_ttl() -> float:
 
 # optimization-only path: disabled by default, read results only.
 _READ_CACHE = TTLCache[str, list[CanonicalMetadataRow]](ttl_seconds=_env_cache_ttl())
+
+
+def _ensure_cache_ttl(session: Session) -> None:
+    global _READ_CACHE
+    ttl_seconds = _env_cache_ttl(session)
+    if abs(getattr(_READ_CACHE, "_ttl_seconds", ttl_seconds) - ttl_seconds) > 1e-9:
+        _READ_CACHE = TTLCache(ttl_seconds=ttl_seconds)
 
 
 def _rows_to_dataclass(rows: list[dict[str, Any]]) -> list[CanonicalMetadataRow]:
@@ -181,12 +200,16 @@ def fetch_canonical_metadata(
     use_cache: bool | None = None,
     metrics_run_id: str | None = None,
 ) -> list[CanonicalMetadataRow]:
-    cache_enabled = _env_cache_enabled() if use_cache is None else bool(use_cache)
+    if use_cache is None:
+        cache_enabled = _env_cache_enabled(session)
+    else:
+        cache_enabled = bool(use_cache)
     source_label = "mv" if use_mv else "base"
     cache_key = f"source={'mv' if use_mv else 'base'}|sample_size={sample_size}"
 
     # optimization-only path: read cache never affects decision semantics.
     if cache_enabled:
+        _ensure_cache_ttl(session)
         cached = _READ_CACHE.get(cache_key)
         cache_stats = _READ_CACHE.stats()
         record_canonical_read_cache_metrics(

--- a/media_manager/app/persistence/materialized_reads.py
+++ b/media_manager/app/persistence/materialized_reads.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import inspect
 import os
 import random
+import threading
 import uuid
 from dataclasses import dataclass
 from time import perf_counter
@@ -127,13 +128,15 @@ def _env_cache_ttl(session: Session | None = None) -> float:
 
 # optimization-only path: disabled by default, read results only.
 _READ_CACHE = TTLCache[str, list[CanonicalMetadataRow]](ttl_seconds=_env_cache_ttl())
+_READ_CACHE_LOCK = threading.Lock()
 
 
 def _ensure_cache_ttl(session: Session) -> None:
     global _READ_CACHE
     ttl_seconds = _env_cache_ttl(session)
-    if abs(getattr(_READ_CACHE, "_ttl_seconds", ttl_seconds) - ttl_seconds) > 1e-9:
-        _READ_CACHE = TTLCache(ttl_seconds=ttl_seconds)
+    with _READ_CACHE_LOCK:
+        if abs(getattr(_READ_CACHE, "_ttl_seconds", ttl_seconds) - ttl_seconds) > 1e-9:
+            _READ_CACHE = TTLCache(ttl_seconds=ttl_seconds)
 
 
 def _rows_to_dataclass(rows: list[dict[str, Any]]) -> list[CanonicalMetadataRow]:
@@ -210,8 +213,9 @@ def fetch_canonical_metadata(
     # optimization-only path: read cache never affects decision semantics.
     if cache_enabled:
         _ensure_cache_ttl(session)
-        cached = _READ_CACHE.get(cache_key)
-        cache_stats = _READ_CACHE.stats()
+        with _READ_CACHE_LOCK:
+            cached = _READ_CACHE.get(cache_key)
+            cache_stats = _READ_CACHE.stats()
         record_canonical_read_cache_metrics(
             run_id=metrics_run_id,
             source=source_label,
@@ -225,7 +229,8 @@ def fetch_canonical_metadata(
 
     rows = _query_rows(session, use_mv=use_mv, sample_size=sample_size)
     if cache_enabled:
-        _READ_CACHE.set(cache_key, rows)
+        with _READ_CACHE_LOCK:
+            _READ_CACHE.set(cache_key, rows)
     return rows
 
 

--- a/media_manager/app/persistence/models.py
+++ b/media_manager/app/persistence/models.py
@@ -1348,3 +1348,46 @@ class OperatorPolicySetting(Base):
     )
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default=text("1"))
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=utc_now)
+
+
+class AppSetting(Base):
+    __tablename__ = "app_settings"
+
+    key: Mapped[str] = mapped_column(Text, primary_key=True, nullable=False)
+    value_json: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    value_type: Mapped[str] = mapped_column(Text, nullable=False)
+    category: Mapped[str] = mapped_column(Text, nullable=False)
+    scope: Mapped[str] = mapped_column(Text, nullable=False, default="global", server_default=text("'global'"))
+    is_sensitive: Mapped[bool] = mapped_column(nullable=False, default=False, server_default=text("false"))
+    updated_by: Mapped[str] = mapped_column(Text, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
+        server_default=text("now()"),
+    )
+    version: Mapped[int] = mapped_column(BigInteger, nullable=False, default=1, server_default=text("1"))
+    source: Mapped[str] = mapped_column(Text, nullable=False, default="api", server_default=text("'api'"))
+
+
+class AppSettingHistory(Base):
+    __tablename__ = "app_settings_history"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True, nullable=False)
+    key: Mapped[str] = mapped_column(Text, nullable=False)
+    old_value_json: Mapped[dict[str, object] | None] = mapped_column(JSONB, nullable=True)
+    new_value_json: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    changed_by: Mapped[str] = mapped_column(Text, nullable=False)
+    changed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
+        server_default=text("now()"),
+    )
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+Index("idx_app_settings_category", AppSetting.category)
+Index("idx_app_settings_updated_at", AppSetting.updated_at.desc())
+Index("idx_app_settings_history_key_time", AppSettingHistory.key, AppSettingHistory.changed_at.desc())

--- a/media_manager/app/persistence/operator_console.py
+++ b/media_manager/app/persistence/operator_console.py
@@ -27,6 +27,7 @@ from media_manager.app.persistence.discovery_query import (
     DiscoveryQueryParams,
     DiscoveryQueryService,
 )
+from media_manager.app.persistence.app_settings import AppSettingsService
 from media_manager.app.persistence.duplicate_reviews import compute_duplicate_group_signature
 from media_manager.app.persistence.duplicate_integrity_recommendations import (
     DuplicateRecommendation,
@@ -75,11 +76,18 @@ def _env_truthy(name: str, default: str = "false") -> bool:
     return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _video_thumbnails_enabled() -> bool:
-    return _env_truthy("MEDIA_MANAGER_VIDEO_THUMBNAILS_ENABLED")
+def _video_thumbnails_enabled(session_factory: sessionmaker[Session] | None = None) -> bool:
+    if session_factory is None:
+        return _env_truthy("MEDIA_MANAGER_VIDEO_THUMBNAILS_ENABLED")
+    return bool(AppSettingsService(session_factory).resolve_runtime_value("video_thumbnails_enabled", logger=logger))
 
 
-def _video_thumbnail_cache_dir() -> Path:
+def _video_thumbnail_cache_dir(session_factory: sessionmaker[Session] | None = None) -> Path:
+    if session_factory is not None:
+        raw = str(
+            AppSettingsService(session_factory).resolve_runtime_value("video_thumbnail_cache_dir", logger=logger)
+        ).strip()
+        return Path(raw)
     raw = (os.getenv("MEDIA_MANAGER_VIDEO_THUMBNAIL_CACHE_DIR", "") or "").strip()
     if raw:
         return Path(raw).expanduser()
@@ -1066,7 +1074,7 @@ class OperatorConsoleReadService:
             thumbnail_url = f"/api/thumbnail/{instance_id_str}" if is_image else None
             media_url = f"/media/{instance_id_str}" if is_image else None
             preview_url = thumbnail_url
-            if media_type == "VID" and _video_thumbnails_enabled():
+            if media_type == "VID" and _video_thumbnails_enabled(self._session_factory):
                 preview_url = f"/api/video-thumbnail/{instance_id_str}"
             canonical_instance_id = latest_canonical_by_content.get(content_id)
             existing_group = grouped.setdefault(content_id, [])
@@ -1877,7 +1885,7 @@ class OperatorConsoleReadService:
 
     def resolve_video_thumbnail_source(self, file_instance_id: UUID) -> tuple[Path, str] | None:
         """Resolve or generate a cached video thumbnail for an active video instance."""
-        if not _video_thumbnails_enabled():
+        if not _video_thumbnails_enabled(self._session_factory):
             return None
 
         path = self._resolve_active_instance_path(file_instance_id)
@@ -1953,7 +1961,7 @@ class OperatorConsoleReadService:
         )
 
     def _poster_url_for_gallery_item(self, file_id: str, file_type: str) -> str | None:
-        if file_type != "video" or not _video_thumbnails_enabled():
+        if file_type != "video" or not _video_thumbnails_enabled(self._session_factory):
             return None
         return f"/api/video-thumbnail/{file_id}"
 
@@ -2026,7 +2034,7 @@ class OperatorConsoleReadService:
         return None
 
     def _ensure_video_thumbnail_cache_dir(self) -> Path | None:
-        cache_dir = _video_thumbnail_cache_dir()
+        cache_dir = _video_thumbnail_cache_dir(self._session_factory)
         try:
             cache_dir.mkdir(parents=True, exist_ok=True)
         except OSError:

--- a/media_manager/app/persistence/planner.py
+++ b/media_manager/app/persistence/planner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
@@ -31,6 +30,7 @@ from media_manager.app.core.path_resolver import (
 )
 from media_manager.app.core.state_machine import RunState, validate_transition
 from media_manager.app.observability import record_planner_metrics, record_planner_stage_duration
+from media_manager.app.persistence.app_settings import AppSettingsService
 from media_manager.app.persistence.base import transactional_session
 from media_manager.app.persistence.decision_intelligence import build_decision_traces, write_decision_trace_artifact
 from media_manager.app.persistence.discovery import process_all_discovery_in_session, process_discovery_paths_in_session
@@ -483,12 +483,9 @@ class PlanningService:
             raise
 
     def _get_metadata_batch_size(self) -> int:
-        raw = os.getenv("METADATA_UPSERT_BATCH_SIZE", "1000")
-        try:
-            value = int(raw)
-        except ValueError:
-            return 1000
-        return min(max(value, 1), 50_000)
+        return int(
+            AppSettingsService(self._session_factory).resolve_runtime_value("metadata_upsert_batch_size", logger=logger)
+        )
 
     def _normalize_path_key(self, raw_path: str, path_key_cache: dict[str, str]) -> str:
         cached = path_key_cache.get(raw_path)

--- a/media_manager/app/workers/benchmark_runner.py
+++ b/media_manager/app/workers/benchmark_runner.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from uuid import UUID
 
 from media_manager.app.core.config import load_environment
+from media_manager.app.persistence.app_settings import AppSettingsService
 from media_manager.app.persistence.admin_benchmarks import run_discovery_benchmark, run_metadata_benchmark
 from media_manager.app.persistence.base import create_db_engine, create_session_factory
 from media_manager.app.persistence.benchmark_runs import BenchmarkRunStore
@@ -101,7 +102,14 @@ def run_once() -> bool:
 
 
 def run_forever() -> None:
-    poll_interval_s = float(os.getenv("MEDIA_MANAGER_BENCHMARK_POLL_INTERVAL_SECONDS", "2.0"))
+    engine = create_db_engine()
+    session_factory = create_session_factory(engine)
+    try:
+        poll_interval_s = float(
+            AppSettingsService(session_factory).resolve_runtime_value("benchmark_poll_interval_seconds", logger=LOGGER)
+        )
+    finally:
+        engine.dispose()
     while True:
         did_work = run_once()
         if not did_work:
@@ -111,7 +119,12 @@ def run_forever() -> None:
 def main() -> None:
     if not _flag_enabled("MEDIA_MANAGER_BENCHMARKS_ENABLED"):
         raise SystemExit("Benchmarks are disabled. Set MEDIA_MANAGER_BENCHMARKS_ENABLED=true to run the worker.")
-    mode = (os.getenv("MEDIA_MANAGER_BENCHMARK_WORKER_MODE", "forever") or "").strip().lower()
+    engine = create_db_engine()
+    session_factory = create_session_factory(engine)
+    try:
+        mode = str(AppSettingsService(session_factory).resolve_runtime_value("benchmark_worker_mode", logger=LOGGER))
+    finally:
+        engine.dispose()
     if mode == "once":
         run_once()
         return

--- a/media_manager/tests/conftest.py
+++ b/media_manager/tests/conftest.py
@@ -58,6 +58,7 @@ def clean_tables(db_engine: Engine) -> None:
                 "canonical_recompute_items, canonical_recompute_runs, canonical_assignments, "
                 "tag_enrichment_items, tag_enrichment_runs, "
                 "benchmark_runs, "
+                "app_settings_history, app_settings, "
                 "integrity_quarantine_records, integrity_check_runs, "
                 "operation_runs, "
                 "media_file, "

--- a/media_manager/tests/test_app_settings_runtime_dual_read.py
+++ b/media_manager/tests/test_app_settings_runtime_dual_read.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import pytest
@@ -12,15 +11,21 @@ from media_manager.app.persistence.planner import PlanningService
 from media_manager.app.workers import benchmark_runner
 
 
-def test_materialized_reads_uses_env_fallback_with_warning(session_factory, caplog, monkeypatch) -> None:
+def test_materialized_reads_uses_env_fallback_with_warning(session_factory, monkeypatch) -> None:
     monkeypatch.setenv("CANONICAL_READ_CACHE_ENABLED", "true")
     monkeypatch.setenv("CANONICAL_READ_CACHE_TTL_SECONDS", "45")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        materialized_reads.LOGGER,
+        "warning",
+        lambda message, *args, **kwargs: calls.append(str(message)),
+    )
 
-    with session_factory() as session, caplog.at_level(logging.WARNING):
+    with session_factory() as session:
         assert materialized_reads._env_cache_enabled(session) is True
         assert materialized_reads._env_cache_ttl(session) == 45.0
 
-    assert "using environment fallback" in caplog.text
+    assert any("using environment fallback" in line for line in calls)
 
 
 def test_materialized_reads_prefers_db_settings(session_factory, monkeypatch) -> None:
@@ -41,13 +46,12 @@ def test_materialized_reads_prefers_db_settings(session_factory, monkeypatch) ->
         assert materialized_reads._env_cache_ttl(session) == 12.5
 
 
-def test_operator_console_video_thumbnail_settings_dual_read(session_factory, caplog, monkeypatch, tmp_path: Path) -> None:
+def test_operator_console_video_thumbnail_settings_dual_read(session_factory, monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("MEDIA_MANAGER_VIDEO_THUMBNAILS_ENABLED", "false")
     monkeypatch.setenv("MEDIA_MANAGER_VIDEO_THUMBNAIL_CACHE_DIR", str((tmp_path / "env-thumbs").resolve()))
 
-    with caplog.at_level(logging.WARNING):
-        assert _video_thumbnails_enabled(session_factory) is False
-        assert _video_thumbnail_cache_dir(session_factory) == (tmp_path / "env-thumbs").resolve()
+    assert _video_thumbnails_enabled(session_factory) is False
+    assert _video_thumbnail_cache_dir(session_factory) == (tmp_path / "env-thumbs").resolve()
 
     service = AppSettingsService(session_factory)
     service.set_value("video_thumbnails_enabled", True, updated_by="tester", source="test", expected_version=0)
@@ -63,12 +67,11 @@ def test_operator_console_video_thumbnail_settings_dual_read(session_factory, ca
     assert _video_thumbnail_cache_dir(session_factory) == (tmp_path / "db-thumbs").resolve()
 
 
-def test_planner_metadata_batch_size_dual_read(session_factory, caplog, monkeypatch) -> None:
+def test_planner_metadata_batch_size_dual_read(session_factory, monkeypatch) -> None:
     planner = PlanningService(session_factory)
     monkeypatch.setenv("METADATA_UPSERT_BATCH_SIZE", "2500")
 
-    with caplog.at_level(logging.WARNING):
-        assert planner._get_metadata_batch_size() == 2500
+    assert planner._get_metadata_batch_size() == 2500
 
     AppSettingsService(session_factory).set_value(
         "metadata_upsert_batch_size",
@@ -104,21 +107,26 @@ def test_benchmark_runner_main_uses_db_first_worker_mode(
 
 
 def test_benchmark_runner_main_warns_and_falls_back_to_env_worker_mode(
-    session_factory, test_database_url: str, monkeypatch, caplog
+    session_factory, test_database_url: str, monkeypatch
 ) -> None:
     monkeypatch.setenv("DATABASE_URL", test_database_url)
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARKS_ENABLED", "true")
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_WORKER_MODE", "once")
-
     calls: list[str] = []
-    monkeypatch.setattr(benchmark_runner, "run_once", lambda: calls.append("once") or False)
-    monkeypatch.setattr(benchmark_runner, "run_forever", lambda: calls.append("forever"))
+    monkeypatch.setattr(
+        benchmark_runner.LOGGER,
+        "warning",
+        lambda message, *args, **kwargs: calls.append(str(message)),
+    )
 
-    with caplog.at_level(logging.WARNING):
-        benchmark_runner.main()
+    run_calls: list[str] = []
+    monkeypatch.setattr(benchmark_runner, "run_once", lambda: run_calls.append("once") or False)
+    monkeypatch.setattr(benchmark_runner, "run_forever", lambda: run_calls.append("forever"))
 
-    assert calls == ["once"]
-    assert "using environment fallback" in caplog.text
+    benchmark_runner.main()
+
+    assert run_calls == ["once"]
+    assert any("using environment fallback" in line for line in calls)
 
 
 def test_benchmark_runner_run_forever_uses_db_first_poll_interval(

--- a/media_manager/tests/test_app_settings_runtime_dual_read.py
+++ b/media_manager/tests/test_app_settings_runtime_dual_read.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from media_manager.app.persistence.app_settings import AppSettingsService
+from media_manager.app.persistence import materialized_reads
+from media_manager.app.persistence.operator_console import _video_thumbnail_cache_dir, _video_thumbnails_enabled
+from media_manager.app.persistence.planner import PlanningService
+from media_manager.app.workers import benchmark_runner
+
+
+def test_materialized_reads_uses_env_fallback_with_warning(session_factory, caplog, monkeypatch) -> None:
+    monkeypatch.setenv("CANONICAL_READ_CACHE_ENABLED", "true")
+    monkeypatch.setenv("CANONICAL_READ_CACHE_TTL_SECONDS", "45")
+
+    with session_factory() as session, caplog.at_level(logging.WARNING):
+        assert materialized_reads._env_cache_enabled(session) is True
+        assert materialized_reads._env_cache_ttl(session) == 45.0
+
+    assert "using environment fallback" in caplog.text
+
+
+def test_materialized_reads_prefers_db_settings(session_factory, monkeypatch) -> None:
+    service = AppSettingsService(session_factory)
+    service.set_value("canonical_read_cache_enabled", False, updated_by="tester", source="test", expected_version=0)
+    service.set_value(
+        "canonical_read_cache_ttl_seconds",
+        12.5,
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+    monkeypatch.setenv("CANONICAL_READ_CACHE_ENABLED", "true")
+    monkeypatch.setenv("CANONICAL_READ_CACHE_TTL_SECONDS", "45")
+
+    with session_factory() as session:
+        assert materialized_reads._env_cache_enabled(session) is False
+        assert materialized_reads._env_cache_ttl(session) == 12.5
+
+
+def test_operator_console_video_thumbnail_settings_dual_read(session_factory, caplog, monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("MEDIA_MANAGER_VIDEO_THUMBNAILS_ENABLED", "false")
+    monkeypatch.setenv("MEDIA_MANAGER_VIDEO_THUMBNAIL_CACHE_DIR", str((tmp_path / "env-thumbs").resolve()))
+
+    with caplog.at_level(logging.WARNING):
+        assert _video_thumbnails_enabled(session_factory) is False
+        assert _video_thumbnail_cache_dir(session_factory) == (tmp_path / "env-thumbs").resolve()
+
+    service = AppSettingsService(session_factory)
+    service.set_value("video_thumbnails_enabled", True, updated_by="tester", source="test", expected_version=0)
+    service.set_value(
+        "video_thumbnail_cache_dir",
+        str((tmp_path / "db-thumbs").resolve()),
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+
+    assert _video_thumbnails_enabled(session_factory) is True
+    assert _video_thumbnail_cache_dir(session_factory) == (tmp_path / "db-thumbs").resolve()
+
+
+def test_planner_metadata_batch_size_dual_read(session_factory, caplog, monkeypatch) -> None:
+    planner = PlanningService(session_factory)
+    monkeypatch.setenv("METADATA_UPSERT_BATCH_SIZE", "2500")
+
+    with caplog.at_level(logging.WARNING):
+        assert planner._get_metadata_batch_size() == 2500
+
+    AppSettingsService(session_factory).set_value(
+        "metadata_upsert_batch_size",
+        500,
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+
+    assert planner._get_metadata_batch_size() == 500
+
+
+def test_benchmark_runner_main_uses_db_first_worker_mode(
+    session_factory, test_database_url: str, monkeypatch
+) -> None:
+    AppSettingsService(session_factory).set_value(
+        "benchmark_worker_mode",
+        "once",
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+    monkeypatch.setenv("DATABASE_URL", test_database_url)
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARKS_ENABLED", "true")
+
+    calls: list[str] = []
+    monkeypatch.setattr(benchmark_runner, "run_once", lambda: calls.append("once") or False)
+    monkeypatch.setattr(benchmark_runner, "run_forever", lambda: calls.append("forever"))
+
+    benchmark_runner.main()
+
+    assert calls == ["once"]
+
+
+def test_benchmark_runner_main_warns_and_falls_back_to_env_worker_mode(
+    session_factory, test_database_url: str, monkeypatch, caplog
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", test_database_url)
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARKS_ENABLED", "true")
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_WORKER_MODE", "once")
+
+    calls: list[str] = []
+    monkeypatch.setattr(benchmark_runner, "run_once", lambda: calls.append("once") or False)
+    monkeypatch.setattr(benchmark_runner, "run_forever", lambda: calls.append("forever"))
+
+    with caplog.at_level(logging.WARNING):
+        benchmark_runner.main()
+
+    assert calls == ["once"]
+    assert "using environment fallback" in caplog.text
+
+
+def test_benchmark_runner_run_forever_uses_db_first_poll_interval(
+    session_factory, test_database_url: str, monkeypatch
+) -> None:
+    AppSettingsService(session_factory).set_value(
+        "benchmark_poll_interval_seconds",
+        7.5,
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+    monkeypatch.setenv("DATABASE_URL", test_database_url)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(benchmark_runner, "run_once", lambda: False)
+
+    def _sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        raise RuntimeError("stop-loop")
+
+    monkeypatch.setattr(benchmark_runner.time, "sleep", _sleep)
+
+    with pytest.raises(RuntimeError, match="stop-loop"):
+        benchmark_runner.run_forever()
+
+    assert sleeps == [7.5]

--- a/media_manager/tests/test_app_settings_service.py
+++ b/media_manager/tests/test_app_settings_service.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from media_manager.app.core.errors import AppSettingsValidationError, AppSettingsVersionConflictError
 from media_manager.app.persistence.app_settings import AppSettingsService, _CATALOG
+from media_manager.app.persistence.models import AppSetting, AppSettingHistory
 
 
 def test_set_value_validates_canonical_policy_enum(session_factory) -> None:
@@ -62,6 +65,28 @@ def test_set_value_rejects_non_positive_cache_ttl(session_factory) -> None:
         )
 
 
+def test_set_value_rejects_boolean_for_numeric_settings(session_factory) -> None:
+    service = AppSettingsService(session_factory)
+
+    with pytest.raises(AppSettingsValidationError):
+        service.set_value(
+            "canonical_read_cache_ttl_seconds",
+            True,
+            updated_by="tester",
+            source="test",
+            expected_version=0,
+        )
+
+    with pytest.raises(AppSettingsValidationError):
+        service.set_value(
+            "metadata_upsert_batch_size",
+            False,
+            updated_by="tester",
+            source="test",
+            expected_version=0,
+        )
+
+
 def test_set_value_uses_optimistic_concurrency(session_factory) -> None:
     service = AppSettingsService(session_factory)
 
@@ -91,6 +116,64 @@ def test_set_value_uses_optimistic_concurrency(session_factory) -> None:
             updated_by="tester",
             source="test",
             expected_version=created.version,
+        )
+
+
+def test_sensitive_history_payloads_are_redacted(session_factory) -> None:
+    service = AppSettingsService(session_factory)
+
+    created = service.set_value(
+        "db_reset_challenge_word",
+        "media-manager",
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+    service.set_value(
+        "db_reset_challenge_word",
+        "rotated-secret",
+        updated_by="tester",
+        source="test",
+        expected_version=created.version,
+    )
+
+    with session_factory() as session:
+        history = (
+            session.query(AppSettingHistory)
+            .filter(AppSettingHistory.key == "db_reset_challenge_word")
+            .order_by(AppSettingHistory.id.asc())
+            .all()
+        )
+
+    assert len(history) == 2
+    assert history[0].old_value_json is None
+    assert history[0].new_value_json == {"value": "<REDACTED>"}
+    assert history[1].old_value_json == {"value": "<REDACTED>"}
+    assert history[1].new_value_json == {"value": "<REDACTED>"}
+
+
+def test_set_value_translates_concurrent_create_conflict(session_factory, monkeypatch) -> None:
+    service = AppSettingsService(session_factory)
+    original_flush = Session.flush
+    triggered = {"value": False}
+
+    def flaky_flush(self, *args, **kwargs):
+        if not triggered["value"]:
+            for obj in self.new:
+                if isinstance(obj, AppSetting) and obj.key == "video_thumbnails_enabled":
+                    triggered["value"] = True
+                    raise IntegrityError("insert", params=None, orig=RuntimeError("duplicate key"))
+        return original_flush(self, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "flush", flaky_flush)
+
+    with pytest.raises(AppSettingsVersionConflictError):
+        service.set_value(
+            "video_thumbnails_enabled",
+            True,
+            updated_by="tester",
+            source="test",
+            expected_version=0,
         )
 
 
@@ -132,6 +215,15 @@ def test_bootstrap_from_env_parses_current_runtime_values(session_factory, monke
     assert service.get_setting("canonical_read_cache_enabled").value is True
     assert service.get_setting("canonical_read_cache_ttl_seconds").value == 30.0
     assert service.get_setting("video_thumbnail_cache_dir").value == str((tmp_path / "thumbs").resolve())
+
+    with session_factory() as session:
+        history = (
+            session.query(AppSettingHistory)
+            .filter(AppSettingHistory.key == "db_reset_challenge_word")
+            .one()
+        )
+
+    assert history.new_value_json == {"value": "<REDACTED>"}
 
 
 def test_bootstrap_is_idempotent_and_skips_existing_rows(session_factory, monkeypatch, tmp_path: Path) -> None:

--- a/media_manager/tests/test_app_settings_service.py
+++ b/media_manager/tests/test_app_settings_service.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from media_manager.app.core.errors import AppSettingsValidationError, AppSettingsVersionConflictError
+from media_manager.app.persistence.app_settings import AppSettingsService, _CATALOG
+
+
+def test_set_value_validates_canonical_policy_enum(session_factory) -> None:
+    service = AppSettingsService(session_factory)
+
+    created = service.set_value(
+        "canonical_policy",
+        "EXIF_FILENAME_FALLBACK",
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+
+    assert created.value == "EXIF_FILENAME_FALLBACK"
+
+
+def test_set_value_rejects_invalid_benchmark_worker_mode(session_factory) -> None:
+    service = AppSettingsService(session_factory)
+
+    with pytest.raises(AppSettingsValidationError):
+        service.set_value(
+            "benchmark_worker_mode",
+            "sometimes",
+            updated_by="tester",
+            source="test",
+            expected_version=0,
+        )
+
+
+def test_set_value_clamps_metadata_batch_size(session_factory) -> None:
+    service = AppSettingsService(session_factory)
+
+    created = service.set_value(
+        "metadata_upsert_batch_size",
+        60_000,
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+
+    assert created.value == 50_000
+
+
+def test_set_value_rejects_non_positive_cache_ttl(session_factory) -> None:
+    service = AppSettingsService(session_factory)
+
+    with pytest.raises(AppSettingsValidationError):
+        service.set_value(
+            "canonical_read_cache_ttl_seconds",
+            0.0,
+            updated_by="tester",
+            source="test",
+            expected_version=0,
+        )
+
+
+def test_set_value_uses_optimistic_concurrency(session_factory) -> None:
+    service = AppSettingsService(session_factory)
+
+    created = service.set_value(
+        "video_thumbnails_enabled",
+        True,
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+
+    updated = service.set_value(
+        "video_thumbnails_enabled",
+        False,
+        updated_by="tester",
+        source="test",
+        expected_version=created.version,
+    )
+
+    assert updated.value is False
+    assert updated.version == created.version + 1
+
+    with pytest.raises(AppSettingsVersionConflictError):
+        service.set_value(
+            "video_thumbnails_enabled",
+            True,
+            updated_by="tester",
+            source="test",
+            expected_version=created.version,
+        )
+
+
+def test_bootstrap_from_env_parses_current_runtime_values(session_factory, monkeypatch, tmp_path: Path) -> None:
+    service = AppSettingsService(session_factory)
+
+    monkeypatch.setenv("MEDIA_REQUIRED_CODES", "OWNER,CONTEXT,TAKEN_DT")
+    monkeypatch.setenv("MEDIA_CANONICAL_STORAGE_PATH", str((tmp_path / "canonical").resolve()))
+    monkeypatch.setenv("MEDIA_DUPLICATE_STORAGE_PATH", str((tmp_path / "duplicates").resolve()))
+    monkeypatch.setenv("MEDIA_MANAGER_TAG_NORMALIZATION_REMOVE_PUNCTUATION", "0")
+    monkeypatch.setenv("MEDIA_CANONICAL_POLICY", "FIRST_SEEN")
+    monkeypatch.setenv("MEDIA_PREFERRED_ROOTS", "")
+    monkeypatch.setenv("CANONICAL_READ_CACHE_ENABLED", "1")
+    monkeypatch.setenv("CANONICAL_READ_CACHE_TTL_SECONDS", "30")
+    monkeypatch.setenv("METADATA_UPSERT_BATCH_SIZE", "1000")
+    monkeypatch.setenv("MEDIA_MANAGER_ALLOW_PLANNER_MV_READS", "false")
+    monkeypatch.setenv("MEDIA_MANAGER_DIRECTORY_PICKER_ENABLED", "true")
+    monkeypatch.setenv(
+        "MEDIA_MANAGER_DIRECTORY_PICKER_ROOTS",
+        "/tmp/a,/tmp/b,/tmp/c",
+    )
+    monkeypatch.setenv("MEDIA_MANAGER_VIDEO_THUMBNAILS_ENABLED", "true")
+    monkeypatch.setenv("MEDIA_MANAGER_VIDEO_THUMBNAIL_CACHE_DIR", str((tmp_path / "thumbs").resolve()))
+    monkeypatch.setenv("MEDIA_MANAGER_DB_RESET_INCLUDE_DYNAMIC", "false")
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARKS_ENABLED", "true")
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_MAX_ITEMS", "10000")
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_POLL_INTERVAL_SECONDS", "2.0")
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_STALE_AFTER_SECONDS", "900")
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_WORKER_MODE", "forever")
+    monkeypatch.setenv("MEDIA_MANAGER_DB_RESET_CHALLENGE_WORD", "media-manager")
+
+    result = service.bootstrap_from_env()
+
+    assert set(result.inserted_keys) == set(_CATALOG)
+    assert result.skipped_keys == ()
+    assert service.get_setting("required_metadata_codes").value == ["OWNER", "CONTEXT", "TAKEN_DT"]
+    assert service.get_setting("preferred_roots").value == []
+    assert service.get_setting("directory_picker_roots").value == ["/tmp/a", "/tmp/b", "/tmp/c"]
+    assert service.get_setting("canonical_read_cache_enabled").value is True
+    assert service.get_setting("canonical_read_cache_ttl_seconds").value == 30.0
+    assert service.get_setting("video_thumbnail_cache_dir").value == str((tmp_path / "thumbs").resolve())
+
+
+def test_bootstrap_is_idempotent_and_skips_existing_rows(session_factory, monkeypatch, tmp_path: Path) -> None:
+    service = AppSettingsService(session_factory)
+    monkeypatch.setenv("MEDIA_CANONICAL_STORAGE_PATH", str((tmp_path / "canonical").resolve()))
+    monkeypatch.setenv("MEDIA_DUPLICATE_STORAGE_PATH", str((tmp_path / "duplicates").resolve()))
+
+    first = service.bootstrap_from_env()
+    second = service.bootstrap_from_env()
+
+    assert len(first.inserted_keys) == len(_CATALOG)
+    assert second.inserted_keys == ()
+    assert set(second.skipped_keys) == set(_CATALOG)
+
+
+def test_bootstrap_rejects_invalid_enum(session_factory, monkeypatch, tmp_path: Path) -> None:
+    service = AppSettingsService(session_factory)
+    monkeypatch.setenv("MEDIA_CANONICAL_STORAGE_PATH", str((tmp_path / "canonical").resolve()))
+    monkeypatch.setenv("MEDIA_DUPLICATE_STORAGE_PATH", str((tmp_path / "duplicates").resolve()))
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_WORKER_MODE", "invalid")
+
+    with pytest.raises(AppSettingsValidationError):
+        service.bootstrap_from_env()

--- a/media_manager/tests/test_app_settings_stale_flags.py
+++ b/media_manager/tests/test_app_settings_stale_flags.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_media_manager_ui_v2_enabled_has_no_runtime_python_references() -> None:
+    runtime_root = Path("media_manager/app")
+    hits = []
+    for candidate in runtime_root.rglob("*.py"):
+        if "MEDIA_MANAGER_UI_V2_ENABLED" in candidate.read_text(encoding="utf-8"):
+            hits.append(str(candidate))
+
+    assert hits == []

--- a/media_manager/tests/test_app_settings_stale_flags.py
+++ b/media_manager/tests/test_app_settings_stale_flags.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 
 def test_media_manager_ui_v2_enabled_has_no_runtime_python_references() -> None:
-    runtime_root = Path("media_manager/app")
+    runtime_root = Path(__file__).resolve().parent.parent / "app"
+    assert runtime_root.is_dir(), f"Runtime directory not found: {runtime_root}"
     hits = []
     for candidate in runtime_root.rglob("*.py"):
         if "MEDIA_MANAGER_UI_V2_ENABLED" in candidate.read_text(encoding="utf-8"):

--- a/migrations/versions/0033_app_settings_pilot.py
+++ b/migrations/versions/0033_app_settings_pilot.py
@@ -1,0 +1,63 @@
+"""add app settings foundation tables
+
+Revision ID: 0033_app_settings_pilot
+Revises: 0032_drop_duplicate_reclaim_record_legacy_columns
+Create Date: 2026-04-03 12:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0033_app_settings_pilot"
+down_revision = "0032_drop_duplicate_reclaim_record_legacy_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS app_settings (
+            key TEXT PRIMARY KEY,
+            value_json JSONB NOT NULL,
+            value_type TEXT NOT NULL,
+            category TEXT NOT NULL,
+            scope TEXT NOT NULL DEFAULT 'global',
+            is_sensitive BOOLEAN NOT NULL DEFAULT false,
+            updated_by TEXT NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            version BIGINT NOT NULL DEFAULT 1,
+            source TEXT NOT NULL DEFAULT 'api'
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS app_settings_history (
+            id BIGSERIAL PRIMARY KEY,
+            key TEXT NOT NULL,
+            old_value_json JSONB NULL,
+            new_value_json JSONB NOT NULL,
+            changed_by TEXT NOT NULL,
+            changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            reason TEXT NULL,
+            source TEXT NOT NULL
+        )
+        """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS idx_app_settings_category ON app_settings (category)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_app_settings_updated_at ON app_settings (updated_at DESC)")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_app_settings_history_key_time "
+        "ON app_settings_history (key, changed_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_app_settings_history_key_time")
+    op.execute("DROP INDEX IF EXISTS idx_app_settings_updated_at")
+    op.execute("DROP INDEX IF EXISTS idx_app_settings_category")
+    op.execute("DROP TABLE IF EXISTS app_settings_history")
+    op.execute("DROP TABLE IF EXISTS app_settings")

--- a/migrations/versions/0033_app_settings_pilot.py
+++ b/migrations/versions/0033_app_settings_pilot.py
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "0033_app_settings_pilot"
-down_revision = "0032_drop_duplicate_reclaim_record_legacy_columns"
+down_revision = "0032"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
This PR implements a narrow `app_settings` pilot under issue #5, with precedence behavior informed by issue #6. It adds a separate durable `app_settings` foundation, typed validation, bootstrap import from current env-backed runtime values, and DB-first dual-read only for the low-risk backend runtime settings that have real readers today. Storage roots, destructive admin controls, planner MV opt-in, benchmark enablement/limits, canonical policy inputs, and other higher-risk or non-reader-backed settings remain env-authoritative in this slice. `MEDIA_MANAGER_UI_V2_ENABLED` remains stale/docs-only and is not bootstrapped or cut over.

## Scope
- add `app_settings` and `app_settings_history` persistence foundation
- add typed catalog, validation, optimistic concurrency, and bootstrap import
- cut over only the verified low-risk backend runtime readers in this slice
- keep all non-allowlisted and higher-risk settings env-authoritative at runtime
- do not add UI, do not broaden config migration, and do not change high-risk authority models

## What changed
- added separate durable settings tables and models for `app_settings` and `app_settings_history`
- added `AppSettingsService` with typed key catalog, validation/normalization, optimistic concurrency, history writes, and bootstrap import from current runtime-parsed env values
- added a bootstrap CLI utility for importing current env-backed values into `app_settings`
- added DB-first dual-read only where there are real backend runtime readers today:
  - `video_thumbnails_enabled`
  - `video_thumbnail_cache_dir`
  - `canonical_read_cache_enabled`
  - `canonical_read_cache_ttl_seconds`
  - `metadata_upsert_batch_size`
  - `benchmark_worker_mode`
  - `benchmark_poll_interval_seconds`
- added focused tests for validation, bootstrap behavior, stale flag confirmation, and the narrow dual-read surface
- corrected the migration chain and tightened the runtime cutover set so it matches the actual live backend reader surface exactly

## Runtime cutover in this slice
Keys truly cut over at runtime:
- `video_thumbnails_enabled`
- `video_thumbnail_cache_dir`
- `canonical_read_cache_enabled`
- `canonical_read_cache_ttl_seconds`
- `metadata_upsert_batch_size`
- `benchmark_worker_mode`
- `benchmark_poll_interval_seconds`

Keys bootstrapped only, not runtime cut over:
- `required_metadata_codes`
- `canonical_policy`
- `preferred_roots`
- `tag_normalization_remove_punctuation`
- `canonical_storage_path`
- `duplicate_storage_path`
- `directory_picker_enabled`
- `directory_picker_roots`
- `allow_planner_mv_reads`
- `benchmarks_enabled`
- `benchmark_max_items`
- `benchmark_stale_after_seconds`
- `db_reset_include_dynamic`
- `db_reset_challenge_word`

## What did not change
- no storage-root authority cutover
- no change to `db_reset_challenge_word` runtime authority
- no change to destructive admin behavior
- no broad env-read removal
- no runtime cutover for `directory_picker_enabled` or `directory_picker_roots`
- no runtime cutover for planner MV opt-in, benchmark enablement/limits, canonical policy inputs, or other higher-risk keys
- no UI changes
- `MEDIA_MANAGER_UI_V2_ENABLED` remains docs-only/stale and is neither bootstrapped nor cut over

## Testing
Focused tests passed:

```bash
./.venv/bin/python -m pytest media_manager/tests/test_app_settings_service.py media_manager/tests/test_app_settings_runtime_dual_read.py media_manager/tests/test_app_settings_stale_flags.py
```

Result:
- `16 passed in 8.63s`

## Risks / follow-ups
- this PR intentionally leaves many bootstrapped keys env-authoritative at runtime; that is by design for this pilot
- `planner.py` changes are narrow and in-scope: the only `app_settings` runtime read there is `metadata_upsert_batch_size`
- future slices can decide whether any currently bootstrapped-only keys should gain runtime DB-first reads, but that is not part of this PR
- `MEDIA_MANAGER_UI_V2_ENABLED` should be handled separately if the repository later decides to remove or repurpose the stale flag

## Issue linkage
- primary implementation issue: #5
- governing precedence / migration policy context: #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent, versioned application settings with change history and DB-first runtime resolution (falls back to environment with warning)
  * Bootstrapping tool to populate settings from environment; runtime resolution used across caching, thumbnails, planner, and benchmark worker

* **Bug Fixes**
  * Safer concurrent updates with optimistic concurrency checks to prevent conflicting writes

* **Tests**
  * New test suites covering runtime dual-read behavior, service validation, bootstrapping, and history redaction

* **Chores**
  * Database migration and test fixtures updated for new settings tables and indexes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->