### PR TITLE
feat: add benchmark app_settings dual-read follow-up

### DIFF
--- a/media_manager/app/persistence/app_settings.py
+++ b/media_manager/app/persistence/app_settings.py
@@ -31,9 +31,11 @@ RUNTIME_DUAL_READ_KEYS = frozenset(
     {
         "video_thumbnails_enabled",
         "video_thumbnail_cache_dir",
+        "benchmarks_enabled",
         "canonical_read_cache_enabled",
         "canonical_read_cache_ttl_seconds",
         "metadata_upsert_batch_size",
+        "benchmark_stale_after_seconds",
         "benchmark_worker_mode",
         "benchmark_poll_interval_seconds",
     }

--- a/media_manager/app/workers/benchmark_runner.py
+++ b/media_manager/app/workers/benchmark_runner.py
@@ -22,6 +22,14 @@ def _flag_enabled(name: str) -> bool:
     return (os.getenv(name, "") or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _runtime_setting(
+    key: str,
+    *,
+    session_factory,
+):
+    return AppSettingsService(session_factory).resolve_runtime_value(key, logger=LOGGER)
+
+
 def run_once() -> bool:
     load_environment()
     engine = create_db_engine()
@@ -30,7 +38,7 @@ def run_once() -> bool:
     operation_runs = OperationRunService(session_factory)
     operation_run_id: UUID | None = None
     try:
-        stale_after_s = max(1.0, float(os.getenv("MEDIA_MANAGER_BENCHMARK_STALE_AFTER_SECONDS", "900")))
+        stale_after_s = max(1.0, float(_runtime_setting("benchmark_stale_after_seconds", session_factory=session_factory)))
         for abandoned in benchmark_runs.abandon_stale_running(stale_after=timedelta(seconds=stale_after_s)):
             operation_runs.fail(
                 UUID(abandoned.operation_run_id),
@@ -117,11 +125,11 @@ def run_forever() -> None:
 
 
 def main() -> None:
-    if not _flag_enabled("MEDIA_MANAGER_BENCHMARKS_ENABLED"):
-        raise SystemExit("Benchmarks are disabled. Set MEDIA_MANAGER_BENCHMARKS_ENABLED=true to run the worker.")
     engine = create_db_engine()
     session_factory = create_session_factory(engine)
     try:
+        if not bool(_runtime_setting("benchmarks_enabled", session_factory=session_factory)):
+            raise SystemExit("Benchmarks are disabled. Set MEDIA_MANAGER_BENCHMARKS_ENABLED=true to run the worker.")
         mode = str(AppSettingsService(session_factory).resolve_runtime_value("benchmark_worker_mode", logger=LOGGER))
     finally:
         engine.dispose()

--- a/media_manager/tests/test_app_settings_runtime_dual_read.py
+++ b/media_manager/tests/test_app_settings_runtime_dual_read.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
 
+from media_manager.app.core.errors import AppSettingsValidationError
 from media_manager.app.persistence.app_settings import AppSettingsService
 from media_manager.app.persistence import materialized_reads
 from media_manager.app.persistence.operator_console import _video_thumbnail_cache_dir, _video_thumbnails_enabled
@@ -106,6 +108,55 @@ def test_benchmark_runner_main_uses_db_first_worker_mode(
     assert calls == ["once"]
 
 
+def test_benchmark_runner_main_uses_db_first_benchmarks_enabled(
+    session_factory, test_database_url: str, monkeypatch
+) -> None:
+    AppSettingsService(session_factory).set_value(
+        "benchmarks_enabled",
+        False,
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+    monkeypatch.setenv("DATABASE_URL", test_database_url)
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARKS_ENABLED", "true")
+
+    monkeypatch.setattr(benchmark_runner, "run_once", lambda: pytest.fail("run_once should not be called"))
+    monkeypatch.setattr(benchmark_runner, "run_forever", lambda: pytest.fail("run_forever should not be called"))
+
+    with pytest.raises(SystemExit, match="Benchmarks are disabled"):
+        benchmark_runner.main()
+
+
+def test_benchmark_runner_main_warns_and_falls_back_to_env_benchmarks_enabled(
+    session_factory, test_database_url: str, monkeypatch
+) -> None:
+    AppSettingsService(session_factory).set_value(
+        "benchmark_worker_mode",
+        "once",
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+    monkeypatch.setenv("DATABASE_URL", test_database_url)
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARKS_ENABLED", "true")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        benchmark_runner.LOGGER,
+        "warning",
+        lambda message, *args, **kwargs: calls.append(str(message)),
+    )
+
+    run_calls: list[str] = []
+    monkeypatch.setattr(benchmark_runner, "run_once", lambda: run_calls.append("once") or False)
+    monkeypatch.setattr(benchmark_runner, "run_forever", lambda: run_calls.append("forever"))
+
+    benchmark_runner.main()
+
+    assert run_calls == ["once"]
+    assert any("using environment fallback" in line for line in calls)
+
+
 def test_benchmark_runner_main_warns_and_falls_back_to_env_worker_mode(
     session_factory, test_database_url: str, monkeypatch
 ) -> None:
@@ -127,6 +178,85 @@ def test_benchmark_runner_main_warns_and_falls_back_to_env_worker_mode(
 
     assert run_calls == ["once"]
     assert any("using environment fallback" in line for line in calls)
+
+
+def test_benchmark_runner_run_once_uses_db_first_stale_after(
+    session_factory, test_database_url: str, monkeypatch
+) -> None:
+    AppSettingsService(session_factory).set_value(
+        "benchmark_stale_after_seconds",
+        12.5,
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+    monkeypatch.setenv("DATABASE_URL", test_database_url)
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_STALE_AFTER_SECONDS", "900")
+
+    observed: dict[str, timedelta] = {}
+
+    class DummyBenchmarkRunStore:
+        def __init__(self, session_factory) -> None:
+            self._session_factory = session_factory
+
+        def abandon_stale_running(self, *, stale_after: timedelta):
+            observed["stale_after"] = stale_after
+            return []
+
+        def claim_next(self):
+            return None
+
+    class DummyOperationRunService:
+        def __init__(self, session_factory) -> None:
+            self._session_factory = session_factory
+
+    monkeypatch.setattr(benchmark_runner, "BenchmarkRunStore", DummyBenchmarkRunStore)
+    monkeypatch.setattr(benchmark_runner, "OperationRunService", DummyOperationRunService)
+
+    assert benchmark_runner.run_once() is False
+    assert observed["stale_after"] == timedelta(seconds=12.5)
+
+
+def test_benchmark_runner_run_once_warns_and_falls_back_to_env_stale_after(
+    session_factory, test_database_url: str, monkeypatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", test_database_url)
+    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_STALE_AFTER_SECONDS", "17.0")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        benchmark_runner.LOGGER,
+        "warning",
+        lambda message, *args, **kwargs: calls.append(str(message)),
+    )
+
+    observed: dict[str, timedelta] = {}
+
+    class DummyBenchmarkRunStore:
+        def __init__(self, session_factory) -> None:
+            self._session_factory = session_factory
+
+        def abandon_stale_running(self, *, stale_after: timedelta):
+            observed["stale_after"] = stale_after
+            return []
+
+        def claim_next(self):
+            return None
+
+    class DummyOperationRunService:
+        def __init__(self, session_factory) -> None:
+            self._session_factory = session_factory
+
+    monkeypatch.setattr(benchmark_runner, "BenchmarkRunStore", DummyBenchmarkRunStore)
+    monkeypatch.setattr(benchmark_runner, "OperationRunService", DummyOperationRunService)
+
+    assert benchmark_runner.run_once() is False
+    assert observed["stale_after"] == timedelta(seconds=17.0)
+    assert any("using environment fallback" in line for line in calls)
+
+
+def test_benchmark_max_items_remains_not_enabled_for_runtime_dual_read(session_factory) -> None:
+    with pytest.raises(AppSettingsValidationError, match="not enabled for runtime dual-read"):
+        AppSettingsService(session_factory).resolve_runtime_value("benchmark_max_items")
 
 
 def test_benchmark_runner_run_forever_uses_db_first_poll_interval(


### PR DESCRIPTION
## Summary
This PR is a new narrow follow-up slice under issue #5, with precedence behavior still guided by issue #6. It extends the existing `app_settings` pilot only for the benchmark runtime settings that have confirmed live backend readers today. In this slice, `benchmarks_enabled` and `benchmark_stale_after_seconds` are now resolved DB-first with env fallback warnings. `benchmark_max_items` remains bootstrapped-only because no real live backend runtime reader was found for it in `benchmark_runner.py`.

## Scope
- Extend the existing `app_settings` runtime dual-read allowlist only for verified benchmark runtime readers
- Update `benchmark_runner.py` only for those verified keys
- Add focused runtime dual-read tests for this narrow benchmark slice
- Do not broaden into general env migration, planner changes, UI, storage authority, or destructive admin authority

## What changed
- Added `benchmarks_enabled` to the `app_settings` runtime dual-read allowlist
- Added `benchmark_stale_after_seconds` to the `app_settings` runtime dual-read allowlist
- Updated `benchmark_runner.py` so:
  - `main()` resolves `benchmarks_enabled` DB-first, then falls back to env with warning
  - `run_once()` resolves `benchmark_stale_after_seconds` DB-first, then falls back to env with warning
- Preserved existing runtime safety behavior for stale benchmark abandonment by keeping the minimum clamp behavior in runtime code
- Added focused tests proving:
  - DB-first behavior for `benchmarks_enabled`
  - env fallback warning behavior for `benchmarks_enabled`
  - DB-first behavior for `benchmark_stale_after_seconds`
  - env fallback warning behavior for `benchmark_stale_after_seconds`
  - `benchmark_max_items` is still not enabled for runtime dual-read

## Runtime Cutover In This Slice
Keys truly cut over at runtime in this slice:
- `benchmarks_enabled`
- `benchmark_stale_after_seconds`

Key intentionally left bootstrapped-only:
- `benchmark_max_items`

## What Did Not Change
- `benchmark_max_items` was not runtime cut over
- `planner.py` was not touched
- no changes to `allow_planner_mv_reads`
- no changes to storage-root runtime authority
- no changes to destructive admin reset authority
- no UI changes
- no broad benchmark-settings migration
- no unrelated config cleanup or architectural refactor

## Testing
Commands run:

```bash
./.venv/bin/python -m pytest media_manager/tests/test_app_settings_runtime_dual_read.py
./.venv/bin/python -m pytest media_manager/tests/test_app_settings_service.py media_manager/tests/test_app_settings_runtime_dual_read.py media_manager/tests/test_app_settings_stale_flags.py
```

Results:
- `12 passed in 6.34s`
- `24 passed in 11.32s`

## Risks / Follow-ups
- This PR intentionally limits runtime cutover to only the benchmark keys with confirmed live backend readers
- `benchmark_max_items` remains bootstrapped-only for now because the current backend path does not read it from env at runtime
- Future slices can evaluate other benchmark or planner-adjacent keys separately, but that is not part of this PR

## Issue Linkage
- Primary implementation issue: #5
- Governing precedence/spec context: #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable benchmark settings to the app's settings system, allowing runtime control of benchmark behavior without restarting.

* **Tests**
  * Enhanced test coverage for benchmark configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->