### PR TITLE
feat: add app settings inspection api

### DIFF
--- a/media_manager/app/persistence/app_settings.py
+++ b/media_manager/app/persistence/app_settings.py
@@ -203,6 +203,10 @@ _CATALOG: dict[str, AppSettingDefinition] = {
 }
 
 
+def get_catalog() -> dict[str, AppSettingDefinition]:
+    return dict(_CATALOG)
+
+
 def _truthy(raw: str) -> bool:
     return raw.strip().lower() in TRUTHY_VALUES
 

--- a/media_manager/app/service_layer/reads.py
+++ b/media_manager/app/service_layer/reads.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from sqlalchemy import func, select
 
-from media_manager.app.persistence.app_settings import AppSettingsService, RUNTIME_DUAL_READ_KEYS, _CATALOG
+from media_manager.app.persistence.app_settings import AppSettingsService, RUNTIME_DUAL_READ_KEYS, get_catalog
 from media_manager.app.persistence.models import (
     CanonicalTag,
     FailureEvent,
@@ -361,7 +361,7 @@ class ReadServices:
         service = AppSettingsService(self.session_factory)
         items: list[dict[str, object]] = []
 
-        for key, definition in _CATALOG.items():
+        for key, definition in get_catalog().items():
             snapshot = service.get_setting(key)
             runtime_dual_read_enabled = key in RUNTIME_DUAL_READ_KEYS
             db_present = snapshot is not None

--- a/media_manager/app/service_layer/reads.py
+++ b/media_manager/app/service_layer/reads.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from sqlalchemy import func, select
 
+from media_manager.app.persistence.app_settings import AppSettingsService, RUNTIME_DUAL_READ_KEYS, _CATALOG
 from media_manager.app.persistence.models import (
     CanonicalTag,
     FailureEvent,
@@ -355,6 +356,40 @@ class ReadServices:
         }
         self.cache.set(cache_key, payload, ttl_s=5)
         return payload
+
+    def admin_app_settings(self) -> dict[str, object]:
+        service = AppSettingsService(self.session_factory)
+        items: list[dict[str, object]] = []
+
+        for key, definition in _CATALOG.items():
+            snapshot = service.get_setting(key)
+            runtime_dual_read_enabled = key in RUNTIME_DUAL_READ_KEYS
+            db_present = snapshot is not None
+            effective_source = None
+            if runtime_dual_read_enabled:
+                effective_source = "db" if db_present else "env_fallback"
+
+            item: dict[str, object] = {
+                "key": key,
+                "category": definition.category,
+                "value_type": definition.value_type,
+                "is_sensitive": definition.is_sensitive,
+                "runtime_dual_read_enabled": runtime_dual_read_enabled,
+                "db_present": db_present,
+                "effective_source": effective_source,
+                "updated_at": snapshot.updated_at.isoformat() if snapshot is not None else None,
+                "updated_by": snapshot.updated_by if snapshot is not None else None,
+                "version": snapshot.version if snapshot is not None else None,
+                "source": snapshot.source if snapshot is not None else None,
+            }
+            if snapshot is not None:
+                if definition.is_sensitive:
+                    item["value_redacted"] = True
+                else:
+                    item["value_json"] = dict(snapshot.value_json)
+            items.append(item)
+
+        return {"items": items}
 
     def admin_observability_failures(self, *, limit: int) -> dict[str, object]:
         bounded_limit = max(1, min(100, int(limit)))

--- a/media_manager/app/service_layer/reads.py
+++ b/media_manager/app/service_layer/reads.py
@@ -361,33 +361,34 @@ class ReadServices:
         service = AppSettingsService(self.session_factory)
         items: list[dict[str, object]] = []
 
-        for key, definition in get_catalog().items():
-            snapshot = service.get_setting(key)
-            runtime_dual_read_enabled = key in RUNTIME_DUAL_READ_KEYS
-            db_present = snapshot is not None
-            effective_source = None
-            if runtime_dual_read_enabled:
-                effective_source = "db" if db_present else "env_fallback"
+        with self.session_factory() as session:
+            for key, definition in get_catalog().items():
+                snapshot = service.get_setting(key, session=session)
+                runtime_dual_read_enabled = key in RUNTIME_DUAL_READ_KEYS
+                db_present = snapshot is not None
+                effective_source = None
+                if runtime_dual_read_enabled:
+                    effective_source = "db" if db_present else "env_fallback"
 
-            item: dict[str, object] = {
-                "key": key,
-                "category": definition.category,
-                "value_type": definition.value_type,
-                "is_sensitive": definition.is_sensitive,
-                "runtime_dual_read_enabled": runtime_dual_read_enabled,
-                "db_present": db_present,
-                "effective_source": effective_source,
-                "updated_at": snapshot.updated_at.isoformat() if snapshot is not None else None,
-                "updated_by": snapshot.updated_by if snapshot is not None else None,
-                "version": snapshot.version if snapshot is not None else None,
-                "source": snapshot.source if snapshot is not None else None,
-            }
-            if snapshot is not None:
-                if definition.is_sensitive:
-                    item["value_redacted"] = True
-                else:
-                    item["value_json"] = dict(snapshot.value_json)
-            items.append(item)
+                item: dict[str, object] = {
+                    "key": key,
+                    "category": definition.category,
+                    "value_type": definition.value_type,
+                    "is_sensitive": definition.is_sensitive,
+                    "runtime_dual_read_enabled": runtime_dual_read_enabled,
+                    "db_present": db_present,
+                    "effective_source": effective_source,
+                    "updated_at": snapshot.updated_at.isoformat() if snapshot is not None else None,
+                    "updated_by": snapshot.updated_by if snapshot is not None else None,
+                    "version": snapshot.version if snapshot is not None else None,
+                    "source": snapshot.source if snapshot is not None else None,
+                }
+                if snapshot is not None:
+                    if definition.is_sensitive:
+                        item["value_redacted"] = True
+                    else:
+                        item["value_json"] = dict(snapshot.value_json)
+                items.append(item)
 
         return {"items": items}
 

--- a/media_manager/tests/test_env_sample_sync.py
+++ b/media_manager/tests/test_env_sample_sync.py
@@ -11,6 +11,7 @@ RE_DEFAULT_PATH = re.compile(r"""_default_path\(\s*["']([A-Z][A-Z0-9_]*)["']\s*,
 RE_DEFAULT_DAYS = re.compile(r"""_default_days\(\s*["']([A-Z][A-Z0-9_]*)["']\s*,""")
 RE_ENV_OVERRIDE_PATH = re.compile(r"""_env_override_path\(\s*["']([A-Z][A-Z0-9_]*)["']\s*,""")
 RE_ENV_OVERRIDE_DAYS = re.compile(r"""_env_override_days\(\s*["']([A-Z][A-Z0-9_]*)["']\s*,""")
+RE_APP_SETTING_ENV_VAR = re.compile(r"""env_var\s*=\s*["']([A-Z][A-Z0-9_]*)["']""")
 RE_ENV_LINE = re.compile(r"""^([A-Z][A-Z0-9_]*)\s*=""")
 
 SCAN_DIRS = ("media_manager", "migrations", "operator_console", "tools")
@@ -54,6 +55,7 @@ def _discovered_env_vars(files: list[Path]) -> set[str]:
         discovered.update(RE_DEFAULT_DAYS.findall(text))
         discovered.update(RE_ENV_OVERRIDE_PATH.findall(text))
         discovered.update(RE_ENV_OVERRIDE_DAYS.findall(text))
+        discovered.update(RE_APP_SETTING_ENV_VAR.findall(text))
     return discovered
 
 

--- a/media_manager/tests/test_service_layer_reads.py
+++ b/media_manager/tests/test_service_layer_reads.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import pytest
 
 import media_manager.app.service_layer.reads as reads_module
+from media_manager.app.persistence.app_settings import AppSettingsService
 from media_manager.app.service_layer.reads import ReadServices
 
 
@@ -38,3 +39,71 @@ def test_duplicate_bin_items_reuses_reclaim_archive_page(monkeypatch: pytest.Mon
     assert payload["page"] == 2
     assert payload["limit"] == 5
     assert payload["items"][0]["item_status"] == "ARCHIVED"
+
+
+def test_admin_app_settings_returns_persisted_non_sensitive_metadata(session_factory) -> None:
+    AppSettingsService(session_factory).set_value(
+        "video_thumbnails_enabled",
+        True,
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+    services = ReadServices(session_factory=session_factory, cache=_FakeCache(invalidations=[]))
+
+    payload = services.admin_app_settings()
+    item = next(entry for entry in payload["items"] if entry["key"] == "video_thumbnails_enabled")
+
+    assert item["db_present"] is True
+    assert item["runtime_dual_read_enabled"] is True
+    assert item["effective_source"] == "db"
+    assert item["updated_by"] == "tester"
+    assert item["version"] == 1
+    assert item["source"] == "test"
+    assert item["value_json"] == {"value": True}
+
+
+def test_admin_app_settings_dual_read_key_without_db_row_uses_env_fallback(session_factory) -> None:
+    services = ReadServices(session_factory=session_factory, cache=_FakeCache(invalidations=[]))
+
+    payload = services.admin_app_settings()
+    item = next(entry for entry in payload["items"] if entry["key"] == "benchmark_worker_mode")
+
+    assert item["runtime_dual_read_enabled"] is True
+    assert item["db_present"] is False
+    assert item["effective_source"] == "env_fallback"
+    assert item["updated_at"] is None
+    assert item["updated_by"] is None
+    assert item["version"] is None
+    assert item["source"] is None
+
+
+def test_admin_app_settings_non_dual_read_key_is_conservative(session_factory) -> None:
+    services = ReadServices(session_factory=session_factory, cache=_FakeCache(invalidations=[]))
+
+    payload = services.admin_app_settings()
+    item = next(entry for entry in payload["items"] if entry["key"] == "directory_picker_enabled")
+
+    assert item["db_present"] is False
+    assert item["runtime_dual_read_enabled"] is False
+    assert item["effective_source"] is None
+
+
+def test_admin_app_settings_sensitive_value_is_redacted(session_factory) -> None:
+    AppSettingsService(session_factory).set_value(
+        "db_reset_challenge_word",
+        "media-manager",
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+    services = ReadServices(session_factory=session_factory, cache=_FakeCache(invalidations=[]))
+
+    payload = services.admin_app_settings()
+    item = next(entry for entry in payload["items"] if entry["key"] == "db_reset_challenge_word")
+
+    assert item["db_present"] is True
+    assert item["runtime_dual_read_enabled"] is False
+    assert item["effective_source"] is None
+    assert item["value_redacted"] is True
+    assert "value_json" not in item

--- a/operator_console/main.py
+++ b/operator_console/main.py
@@ -1213,6 +1213,12 @@ def create_app() -> FastAPI:
     ) -> JSONResponse:
         return _execute_read("admin-observability-summary", services.admin_observability_summary)
 
+    @app.get("/api/admin/app-settings")
+    def admin_app_settings(
+        services: ReadServices = Depends(get_read_services),
+    ) -> JSONResponse:
+        return _execute_read("admin-app-settings", services.admin_app_settings)
+
     @app.get("/api/admin/observability/operation-runs")
     def admin_observability_operation_runs(
         limit: int = Query(default=50),

--- a/operator_console/tests/test_main.py
+++ b/operator_console/tests/test_main.py
@@ -1264,6 +1264,39 @@ class _FakeReadServices:
             "latest_metrics": self.latest_metrics(),
         }
 
+    def admin_app_settings(self) -> dict[str, object]:
+        return {
+            "items": [
+                {
+                    "key": "video_thumbnails_enabled",
+                    "category": "ui",
+                    "value_type": "bool",
+                    "is_sensitive": False,
+                    "runtime_dual_read_enabled": True,
+                    "db_present": True,
+                    "effective_source": "db",
+                    "updated_at": "2026-03-14T10:00:00+00:00",
+                    "updated_by": "tester",
+                    "version": 1,
+                    "source": "test",
+                    "value_json": {"value": True},
+                },
+                {
+                    "key": "directory_picker_enabled",
+                    "category": "ui",
+                    "value_type": "bool",
+                    "is_sensitive": False,
+                    "runtime_dual_read_enabled": False,
+                    "db_present": False,
+                    "effective_source": None,
+                    "updated_at": None,
+                    "updated_by": None,
+                    "version": None,
+                    "source": None,
+                },
+            ]
+        }
+
     def admin_observability_failures(self, *, limit: int) -> dict[str, object]:
         _ = limit
         return {
@@ -3614,6 +3647,24 @@ def test_admin_observability_summary_returns_envelope() -> None:
     assert payload["ok"] is True
     assert payload["data"]["result"]["metrics_enabled"] is True
     assert payload["data"]["result"]["recent_failure_count"] == 2
+
+
+def test_admin_app_settings_returns_envelope() -> None:
+    app.dependency_overrides[get_read_services] = _FakeReadServices
+    client = TestClient(app)
+    try:
+        response = client.get("/api/admin/app-settings")
+    finally:
+        app.dependency_overrides.clear()
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    items = payload["data"]["result"]["items"]
+    dual_read = next(item for item in items if item["key"] == "video_thumbnails_enabled")
+    non_dual_read = next(item for item in items if item["key"] == "directory_picker_enabled")
+    assert dual_read["effective_source"] == "db"
+    assert non_dual_read["effective_source"] is None
+    assert "mutation" not in payload["data"]["result"]
 
 
 def test_admin_observability_failures_returns_envelope() -> None:


### PR DESCRIPTION
## Summary
Add a narrow backend-only read surface for `app_settings` inspection.

This PR adds:
- `ReadServices.admin_app_settings()`
- `GET /api/admin/app-settings`
- focused service and API tests for persisted metadata, dual-read status, and conservative `effective_source` behavior

## Why
Issue #16 calls for a low-risk inspection surface so operators and developers can see:
- catalogued `app_settings` keys
- persisted row metadata
- whether a key is approved for runtime dual-read
- `effective_source` only for the already approved runtime dual-read keys

This follows the existing `app_settings` foundation from #5 and the precedence policy from #6.

## Scope / Safety
Kept intentionally narrow:
- backend/API only
- no GUI or admin page changes
- no mutation endpoints
- no new runtime cutover keys
- no `app_settings_history` exposure
- no raw env dump
- no planner, storage-root, or destructive-admin authority changes
- no `effective_value` field

## Validation
Passed:
- `./.venv/bin/python -m pytest media_manager/tests/test_service_layer_reads.py operator_console/tests/test_main.py`
- `./.venv/bin/python -m pytest media_manager/tests/test_app_settings_runtime_dual_read.py media_manager/tests/test_app_settings_service.py`

Results:
- `129 passed, 38 warnings in 5.47s`
- `23 passed in 10.73s`

## Notes
Conservative choice:
- the API path is `/api/admin/app-settings` to match the repo's existing read-route pattern
- `effective_source` is returned as `null` for non-dual-read keys rather than being omitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin endpoint to list application settings with catalog metadata, sensitivity flags, DB presence, effective source (DB vs env fallback), runtime dual-read indication, and audit/version fields.
  * Non-sensitive values returned as JSON; sensitive values are redacted.

* **Tests**
  * Added unit and endpoint tests covering persisted, missing, dual-read, non-dual-read, and sensitive-setting behaviors.

* **Chores**
  * Expanded environment-variable discovery to include app-setting env patterns and exposed catalog access for reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->