### PR TITLE
feat: add app settings inspection admin UI

### DIFF
--- a/operator_console/gui_app/src/lib/api/endpoints/admin.ts
+++ b/operator_console/gui_app/src/lib/api/endpoints/admin.ts
@@ -2,6 +2,7 @@ import { apiGet, apiPost } from "@/lib/api/client";
 import { withData } from "@/lib/api/envelope";
 import { mapObservabilityFailures, mapRunItem } from "@/lib/api/mappers/runs";
 import type {
+  AppSettingsInspection,
   BenchmarkQueueResult,
   BenchmarkRun,
   DbResetPreview,
@@ -17,6 +18,9 @@ export const adminDbReset = async (params: { dry_run: boolean; challenge_word?: 
     challenge_word: params.challenge_word,
   });
 };
+
+export const getAdminAppSettings = async () =>
+  apiGet<AppSettingsInspection>("/admin/app-settings");
 
 export const getAdminObservabilitySummary = async () =>
   apiGet<ObservabilitySummary>("/admin/observability/summary");

--- a/operator_console/gui_app/src/lib/api/queryKeys.ts
+++ b/operator_console/gui_app/src/lib/api/queryKeys.ts
@@ -33,6 +33,7 @@ export const queryKeys = {
   analytics: ["analytics"] as const,
   directoryPickerCapability: ["directory-picker", "capability"] as const,
   directoryPickerListing: (path: string) => ["directory-picker", "listing", { path }] as const,
+  adminAppSettings: ["admin", "app-settings"] as const,
   adminObservabilitySummary: ["admin", "observability", "summary"] as const,
   adminObservabilityRuns: (params?: { limit?: number; operation_type?: string; status?: string }) =>
     ["admin", "observability", "runs", params ?? {}] as const,
@@ -63,6 +64,7 @@ export const allReadQueryRoots = [
   queryKeys.integrityDashboard,
   queryKeys.policy,
   queryKeys.analytics,
+  queryKeys.adminAppSettings,
   queryKeys.adminObservabilitySummary,
   queryKeys.benchmarkRunsRoot,
 ] as const;

--- a/operator_console/gui_app/src/pages/AdminPage.tsx
+++ b/operator_console/gui_app/src/pages/AdminPage.tsx
@@ -54,6 +54,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   adminDbReset,
   cancelBenchmarkRun,
+  getAdminAppSettings,
   getAdminObservabilityFailures,
   getAdminObservabilityMetricsSeries,
   getAdminObservabilityOperationRuns,
@@ -79,6 +80,8 @@ import { queryKeys } from "@/lib/api/queryKeys";
 import { queryOptions } from "@/lib/api/queryOptions";
 import type {
   AnalyticsSummary,
+  AppSettingInspectionItem,
+  AppSettingsInspection,
   BenchmarkRun,
   DbResetPreview,
   DbResetResult,
@@ -135,6 +138,13 @@ function getAdminTab(value: string | null): AdminTab {
 
 function formatBucketLabel(timestamp: string) {
   return new Date(timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatOptionalTimestamp(value: string | null) {
+  if (!value) return "Not recorded";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
 }
 
 function formatJobName(operationType: string) {
@@ -315,6 +325,98 @@ function formatPolicyUpdatedAt(value: string | null) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
   return date.toLocaleString();
+}
+
+function describeAppSettingRuntime(item: AppSettingInspectionItem) {
+  if (!item.runtime_dual_read_enabled) {
+    return {
+      label: "Inspection only",
+      severity: "neutral" as const,
+      detail: "DB presence does not make this an active runtime authority.",
+      sourceLabel: null,
+      sourceSeverity: "neutral" as const,
+    };
+  }
+
+  if (item.effective_source === "db") {
+    return {
+      label: "Dual-read enabled",
+      severity: "success" as const,
+      detail: "Runtime may read DB or env fallback depending on effective source.",
+      sourceLabel: "Runtime source: DB",
+      sourceSeverity: "success" as const,
+    };
+  }
+
+  if (item.effective_source === "env_fallback") {
+    return {
+      label: "Dual-read enabled",
+      severity: "success" as const,
+      detail: "Runtime may read DB or env fallback depending on effective source.",
+      sourceLabel: "Runtime source: env fallback",
+      sourceSeverity: "info" as const,
+    };
+  }
+
+  return {
+    label: "Dual-read enabled",
+    severity: "success" as const,
+    detail: "Runtime may read DB or env fallback depending on effective source.",
+    sourceLabel: "Runtime source not active",
+    sourceSeverity: "neutral" as const,
+  };
+}
+
+function describeAppSettingDbState(item: AppSettingInspectionItem) {
+  if (!item.db_present) {
+    return {
+      label: "No DB value",
+      severity: "neutral" as const,
+      detail: "No durable app_settings row present.",
+    };
+  }
+
+  return {
+    label: "DB value present",
+    severity: "success" as const,
+    detail: "Durable row available for inspection.",
+  };
+}
+
+function AppSettingValueCell({ item }: { item: AppSettingInspectionItem }) {
+  const [open, setOpen] = useState(false);
+
+  if (item.is_sensitive || item.value_redacted) {
+    return (
+      <div className="space-y-1">
+        <StatusBadge label="Sensitive value redacted" severity="caution" />
+        <p className="max-w-[18rem] text-xs text-muted-foreground">Metadata visible; raw value hidden.</p>
+      </div>
+    );
+  }
+
+  if (!item.db_present || item.value_json == null) {
+    return <p className="max-w-[18rem] text-xs text-muted-foreground">No durable DB value available to display.</p>;
+  }
+
+  const preview = JSON.stringify(item.value_json);
+  const truncatedPreview = preview.length > 88 ? `${preview.slice(0, 88)}...` : preview;
+
+  return (
+    <div className="max-w-[22rem] space-y-2">
+      <p className="font-mono text-xs text-muted-foreground break-all">{truncatedPreview}</p>
+      <Collapsible open={open} onOpenChange={setOpen} className="rounded-xl border bg-background/80">
+        <CollapsibleTrigger asChild>
+          <Button variant="ghost" size="sm" className="h-7 px-2 text-xs">
+            {open ? "Hide JSON" : "View JSON"}
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="border-t px-3 py-3">
+          <JsonViewer data={item.value_json} title="Stored value" maxHeight="160px" />
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
 }
 
 function PolicyChoiceCard({
@@ -1886,6 +1988,10 @@ function IntegrityCheckTab() {
 function SystemHealthTab() {
   const queryClient = useQueryClient();
   const [includeCurrentDay, setIncludeCurrentDay] = useState(false);
+  const appSettingsQuery = useQuery({
+    queryKey: queryKeys.adminAppSettings,
+    queryFn: getAdminAppSettings,
+  });
   const summaryQuery = useQuery({
     queryKey: queryKeys.adminObservabilitySummary,
     queryFn: getAdminObservabilitySummary,
@@ -1908,6 +2014,7 @@ function SystemHealthTab() {
   });
 
   const summary = summaryQuery.data?.data as ObservabilitySummary | undefined;
+  const appSettings = ((appSettingsQuery.data?.data as AppSettingsInspection | undefined)?.items ?? []);
   const failures = failuresQuery.data?.data;
   const series = seriesQuery.data?.data as ObservabilityMetricsSeries | undefined;
   const reconcileMutation = useMutation({
@@ -1943,6 +2050,78 @@ function SystemHealthTab() {
   }
 
   const reconcileResult = reconcileMutation.data?.data as OperationRunReconcileResult | undefined;
+  const appSettingsColumns = [
+    {
+      key: "key",
+      header: "Key",
+      render: (item: AppSettingInspectionItem) => (
+        <div className="space-y-1">
+          <p className="font-mono text-xs font-semibold text-foreground">{item.key}</p>
+          <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">{item.category}</p>
+        </div>
+      ),
+    },
+    {
+      key: "value_type",
+      header: "Type",
+      render: (item: AppSettingInspectionItem) => (
+        <span className="font-mono text-xs text-muted-foreground">{item.value_type}</span>
+      ),
+    },
+    {
+      key: "runtime_status",
+      header: "Runtime status",
+      render: (item: AppSettingInspectionItem) => {
+        const runtime = describeAppSettingRuntime(item);
+        return (
+          <div className="space-y-2">
+            <StatusBadge label={runtime.label} severity={runtime.severity} />
+            {runtime.sourceLabel ? <StatusBadge label={runtime.sourceLabel} severity={runtime.sourceSeverity} /> : null}
+            <p className="max-w-[18rem] text-xs text-muted-foreground">{runtime.detail}</p>
+          </div>
+        );
+      },
+    },
+    {
+      key: "db_state",
+      header: "DB state",
+      render: (item: AppSettingInspectionItem) => {
+        const state = describeAppSettingDbState(item);
+        return (
+          <div className="space-y-2">
+            <StatusBadge label={state.label} severity={state.severity} />
+            <p className="max-w-[16rem] text-xs text-muted-foreground">{state.detail}</p>
+          </div>
+        );
+      },
+    },
+    {
+      key: "value",
+      header: "Value",
+      render: (item: AppSettingInspectionItem) => <AppSettingValueCell item={item} />,
+    },
+    {
+      key: "updated_at",
+      header: "Updated",
+      render: (item: AppSettingInspectionItem) => {
+        const metadata = [
+          item.updated_by ? `by ${item.updated_by}` : null,
+          item.version != null ? `v${item.version}` : null,
+          item.source ?? null,
+        ].filter(Boolean);
+
+        return (
+          <div className="space-y-1">
+            <p className="text-sm text-foreground">{formatOptionalTimestamp(item.updated_at)}</p>
+            <p className="max-w-[16rem] text-xs text-muted-foreground">
+              {metadata.length ? metadata.join(" • ") : "No update metadata recorded."}
+            </p>
+          </div>
+        );
+      },
+    },
+  ];
+  const appSettingsError = getErrorMessage(appSettingsQuery.error);
 
   return (
     <div className="space-y-6">
@@ -2109,6 +2288,34 @@ function SystemHealthTab() {
               <SeverityBadge value={run.status} />
             </div>
           ))}
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-[28px] border-border/70 shadow-sm">
+        <CardHeader>
+          <CardTitle>App settings inspection</CardTitle>
+          <CardDescription>
+            Read-only view of durable app_settings rows. Inspection-only rows do not imply active runtime DB authority
+            outside the approved dual-read allowlist.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            <StatusBadge label="Dual-read enabled" severity="success" />
+            <StatusBadge label="Inspection only" severity="neutral" />
+            <StatusBadge label="Sensitive value redacted" severity="caution" />
+          </div>
+
+          {appSettingsError ? (
+            <ErrorAlert message={`Unable to load app settings inspection. ${appSettingsError}`} />
+          ) : (
+            <DataTable
+              columns={appSettingsColumns}
+              data={appSettings}
+              loading={appSettingsQuery.isLoading}
+              emptyMessage="No app settings were returned by the inspection endpoint."
+            />
+          )}
         </CardContent>
       </Card>
     </div>

--- a/operator_console/gui_app/src/pages/AdminPage.tsx
+++ b/operator_console/gui_app/src/pages/AdminPage.tsx
@@ -320,13 +320,6 @@ function explainPolicyRule(rule: string): string {
     }
 }
 
-function formatPolicyUpdatedAt(value: string | null) {
-  if (!value) return "Not recorded";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString();
-}
-
 function describeAppSettingRuntime(item: AppSettingInspectionItem) {
   if (!item.runtime_dual_read_enabled) {
     return {
@@ -1469,7 +1462,7 @@ function LibraryRulesTab() {
             </div>
             <div className="rounded-2xl border border-border/70 bg-background/80 p-4">
               <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">Updated at</p>
-              <p className="mt-2 text-sm text-foreground">{formatPolicyUpdatedAt(policy.metadata.updated_at)}</p>
+              <p className="mt-2 text-sm text-foreground">{formatOptionalTimestamp(policy.metadata.updated_at)}</p>
             </div>
           </div>
           <div className="rounded-2xl border border-border/70 bg-background/80 p-4">

--- a/operator_console/gui_app/src/test/admin-page.test.tsx
+++ b/operator_console/gui_app/src/test/admin-page.test.tsx
@@ -14,6 +14,7 @@ class MockResizeObserver {
 const mocks = vi.hoisted(() => ({
   adminDbReset: vi.fn(),
   cancelBenchmarkRun: vi.fn(),
+  getAdminAppSettings: vi.fn(),
   getAdminObservabilityFailures: vi.fn(),
   getAdminObservabilityMetricsSeries: vi.fn(),
   getAdminObservabilityOperationRuns: vi.fn(),
@@ -39,6 +40,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/lib/api/endpoints", () => ({
   adminDbReset: mocks.adminDbReset,
   cancelBenchmarkRun: mocks.cancelBenchmarkRun,
+  getAdminAppSettings: mocks.getAdminAppSettings,
   getAdminObservabilityFailures: mocks.getAdminObservabilityFailures,
   getAdminObservabilityMetricsSeries: mocks.getAdminObservabilityMetricsSeries,
   getAdminObservabilityOperationRuns: mocks.getAdminObservabilityOperationRuns,
@@ -240,6 +242,53 @@ describe("Admin page", () => {
         include_current_day: false,
       },
     });
+    mocks.getAdminAppSettings.mockResolvedValue({
+      data: {
+        items: [
+          {
+            key: "video_thumbnails_enabled",
+            category: "ui",
+            value_type: "bool",
+            is_sensitive: false,
+            runtime_dual_read_enabled: true,
+            db_present: true,
+            effective_source: "db",
+            updated_at: "2026-03-20T10:00:00Z",
+            updated_by: "tester",
+            version: 1,
+            source: "bootstrap",
+            value_json: { value: true },
+          },
+          {
+            key: "directory_picker_enabled",
+            category: "ui",
+            value_type: "bool",
+            is_sensitive: false,
+            runtime_dual_read_enabled: false,
+            db_present: false,
+            effective_source: null,
+            updated_at: null,
+            updated_by: null,
+            version: null,
+            source: null,
+          },
+          {
+            key: "admin_api_token",
+            category: "admin_safety",
+            value_type: "string",
+            is_sensitive: true,
+            runtime_dual_read_enabled: true,
+            db_present: true,
+            effective_source: "env_fallback",
+            updated_at: "2026-03-20T11:00:00Z",
+            updated_by: "tester",
+            version: 2,
+            source: "bootstrap",
+            value_redacted: true,
+          },
+        ],
+      },
+    });
   });
 
   afterEach(() => {
@@ -377,5 +426,57 @@ describe("Admin page", () => {
       expect(mocks.reconcileStaleOperationRuns).toHaveBeenCalledWith({ include_current_day: true }),
     );
     expect(await screen.findByText(/Included today: Yes/)).toBeInTheDocument();
+  });
+
+  it("renders the app settings inspection section with read-only values", async () => {
+    renderSystemHealthPage();
+
+    expect(await screen.findByText("App settings inspection")).toBeInTheDocument();
+    expect(screen.getByText("video_thumbnails_enabled")).toBeInTheDocument();
+    expect(screen.getAllByText("Dual-read enabled").length).toBeGreaterThan(0);
+    expect(screen.getByText("Runtime source: DB")).toBeInTheDocument();
+    expect(screen.getByText('{"value":true}')).toBeInTheDocument();
+  });
+
+  it("redacts sensitive app setting values", async () => {
+    renderSystemHealthPage();
+
+    expect((await screen.findAllByText("Sensitive value redacted")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("super-secret-token")).not.toBeInTheDocument();
+  });
+
+  it("labels non-dual-read app settings as inspection only", async () => {
+    renderSystemHealthPage();
+
+    expect(await screen.findByText("directory_picker_enabled")).toBeInTheDocument();
+    expect(screen.getAllByText("Inspection only").length).toBeGreaterThan(0);
+    expect(screen.getByText("DB presence does not make this an active runtime authority.")).toBeInTheDocument();
+    expect(screen.getByText("No DB value")).toBeInTheDocument();
+  });
+
+  it("shows env fallback as the runtime source for dual-read app settings when returned", async () => {
+    renderSystemHealthPage();
+
+    expect(await screen.findByText("Runtime source: env fallback")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when no app settings are returned", async () => {
+    mocks.getAdminAppSettings.mockResolvedValueOnce({
+      data: {
+        items: [],
+      },
+    });
+
+    renderSystemHealthPage();
+
+    expect(await screen.findByText("No app settings were returned by the inspection endpoint.")).toBeInTheDocument();
+  });
+
+  it("shows an error state when app settings inspection fails", async () => {
+    mocks.getAdminAppSettings.mockRejectedValueOnce(new Error("network down"));
+
+    renderSystemHealthPage();
+
+    expect(await screen.findByText("Unable to load app settings inspection. network down")).toBeInTheDocument();
   });
 });

--- a/operator_console/gui_app/src/test/api-endpoints.test.ts
+++ b/operator_console/gui_app/src/test/api-endpoints.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/lib/api/client", () => ({
 import { apiGet, apiPost } from "@/lib/api/client";
 import {
   adminDbReset,
+  getAdminAppSettings,
   getDuplicateBinPolicy,
   getDuplicateBinItems,
   getDirectoryPickerCapability,
@@ -90,6 +91,23 @@ describe("api endpoints", () => {
       dry_run: false,
       challenge_word: "media-manager",
     });
+  });
+
+  it("loads admin app settings through the API client only", async () => {
+    vi.mocked(apiGet).mockResolvedValue({
+      ok: true,
+      workflow_version: "v2-service-layer",
+      schema_version: "schema-1",
+      generated_at: "2026-03-14T00:00:00+00:00",
+      data: {
+        items: [],
+      },
+      errors: [],
+    });
+
+    await getAdminAppSettings();
+
+    expect(apiGet).toHaveBeenCalledWith("/admin/app-settings");
   });
 
   it("derives canonical policy update payloads through the API client only", async () => {

--- a/operator_console/gui_app/src/types/admin.ts
+++ b/operator_console/gui_app/src/types/admin.ts
@@ -1,6 +1,26 @@
 import type { LatestMetrics } from "@/types/dashboard";
 import type { Run } from "@/types/runs";
 
+export interface AppSettingInspectionItem {
+  key: string;
+  category: string;
+  value_type: string;
+  is_sensitive: boolean;
+  runtime_dual_read_enabled: boolean;
+  db_present: boolean;
+  effective_source: "db" | "env_fallback" | null;
+  updated_at: string | null;
+  updated_by: string | null;
+  version: number | null;
+  source: string | null;
+  value_redacted?: boolean;
+  value_json?: Record<string, unknown>;
+}
+
+export interface AppSettingsInspection {
+  items: AppSettingInspectionItem[];
+}
+
 export interface DbResetPreview {
   affected_tables: string[];
   record_counts?: Record<string, number>;


### PR DESCRIPTION
## Summary
Add a narrow read-only `app_settings` inspection section to the existing `/admin` UI.

This PR adds:
- typed frontend support for `GET /api/admin/app-settings`
- a dedicated admin query key and endpoint helper
- a compact inspection table inside the existing `System Health` tab
- explicit runtime-status, DB-state, and redaction labeling
- focused frontend tests for endpoint wiring, rendering, redaction, empty, and error cases

## Why
Issue #18 defines the next safe UI slice on top of the backend inspection endpoint from #16.

The goal is to let operators inspect durable `app_settings` rows and dual-read status from the existing admin workspace without introducing any edit or mutation surface.

## Scope / Safety
Kept intentionally narrow:
- read-only only
- no edit controls or mutation flows
- no backend contract changes
- no new runtime cutover keys
- no authority changes
- no admin IA redesign
- no unrelated module changes

## What changed
- added `AppSettingsInspection` frontend types
- added `getAdminAppSettings()` and `queryKeys.adminAppSettings`
- added an `App settings inspection` card to the `System Health` tab
- render non-sensitive `value_json` read-only
- redact sensitive values explicitly
- label non-dual-read rows as `Inspection only` so DB presence is not mistaken for active runtime authority

## Validation
Passed:
- `npx tsc --noEmit`
- `npm test -- src/test/admin-page.test.tsx src/test/api-endpoints.test.ts`

Notes:
- existing `System Health` tests still emit Recharts zero-size warnings in jsdom; they are warnings only and do not fail the run

## Issue linkage
- Primary implementation thread: #5
- Governing precedence/spec context: #6
- Backend inspection contract: #16
- UI slice implemented here: #18

## CodeRabbit
Please run a CodeRabbit review on this PR even though it is intentionally kept in draft while the slice is reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "App settings inspection" card to Admin → System Health showing keys, type, runtime status, DB state, values (with redaction) and last-updated info; includes sorting/filtering and expandable JSON previews.
  * Integrated backend app-settings fetch so the UI shows live inspection data.

* **Tests**
  * Added unit tests covering rendering, redaction, labels for inspection-only items, runtime source badges, and empty/error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->