### PR TITLE
revert: remove accidental app_settings payload from PR #42

### DIFF
--- a/media_manager/app/service_layer/admin.py
+++ b/media_manager/app/service_layer/admin.py
@@ -9,7 +9,6 @@ from uuid import UUID
 
 from sqlalchemy import inspect, text
 
-from media_manager.app.persistence.app_settings import AppSettingsService, RUNTIME_DUAL_READ_KEYS
 from media_manager.app.persistence.base import transactional_session
 from media_manager.app.persistence.benchmark_runs import BenchmarkRunStore
 from media_manager.app.persistence.models import BenchmarkRunType, OperationRunType
@@ -21,13 +20,6 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_CHALLENGE_WORD = "media-manager"
 DEFAULT_BENCHMARK_MAX_ITEMS = 10_000
 DEFAULT_BENCHMARK_METADATA_BATCH_SIZE = 1_000
-EDITABLE_APP_SETTING_KEYS: frozenset[str] = frozenset(
-    {
-        "video_thumbnails_enabled",
-        "canonical_read_cache_enabled",
-        "canonical_read_cache_ttl_seconds",
-    }
-)
 
 # Dependency-safe truncate order (children first, roots last).
 RESET_TABLE_ALLOWLIST: tuple[str, ...] = (
@@ -195,15 +187,6 @@ class AdminServices:
         return [item.to_dict() for item in self._benchmark_runs().list_history(limit=limit)]
 
     def reconcile_stale_operation_runs(self, *, include_current_day: bool = False) -> dict[str, object]:
-        """
-        Trigger reconciliation of stale started operation runs and return the reconciliation outcome.
-        
-        Parameters:
-            include_current_day (bool): If True, include operation runs started on the current day when scanning for stale runs.
-        
-        Returns:
-            dict[str, object]: Reconciliation result containing keys such as `cutoff` (cutoff timestamp), `scanned_count` (number of runs scanned), and `updated_count` (number of runs updated).
-        """
         result = self._op_runs().reconcile_stale_started_runs(include_current_day=include_current_day)
         LOGGER.info(
             "Manual stale operation run reconciliation completed",
@@ -218,54 +201,7 @@ class AdminServices:
         )
         return result.to_dict()
 
-    def update_app_setting(self, *, key: str, value: object, version: int) -> dict[str, object]:
-        """
-        Update an allowlisted application setting and return a standardized serialized snapshot.
-        
-        Attempts to set `key` to `value` using the provided `version` as the expected version for the update; the change is recorded as performed by the admin UI actor and serialized into a payload suitable for API responses.
-        
-        Parameters:
-            key (str): The application setting key to update; must be present in the allowlist.
-            value (object): The new value for the setting.
-            version (int): The expected current version of the setting (used for optimistic concurrency).
-        
-        Returns:
-            dict[str, object]: A serialized snapshot of the updated app setting containing metadata such as key, category, value/type fields, runtime dual-read flags, update metadata, and either `value_json` or `value_redacted`.
-        
-        Raises:
-            ServiceLayerException: If `key` is not editable (validation error) or if the underlying settings service rejects or fails the update.
-        """
-        if key not in EDITABLE_APP_SETTING_KEYS:
-            raise ServiceLayerException(
-                code="VALIDATION_ERROR",
-                message=f"{key} is not editable in this slice.",
-                http_status=400,
-            )
-
-        service = AppSettingsService(self.session_factory)
-        snapshot = service.set_value(
-            key,
-            value,
-            updated_by="operator_console:admin",
-            source="admin_ui",
-            expected_version=version,
-            reason="allowlisted_admin_update",
-        )
-        return self._serialize_app_setting_snapshot(snapshot=snapshot)
-
     def benchmark_run_detail(self, *, operation_run_id: str) -> dict[str, object]:
-        """
-        Retrieve the benchmark run snapshot for the given operation run id.
-        
-        Parameters:
-            operation_run_id (str): The operation run identifier (string form); it is parsed as a UUID.
-        
-        Returns:
-            dict[str, object]: The benchmark run snapshot serialized as a dictionary.
-        
-        Raises:
-            ServiceLayerException: with `code="NOT_FOUND"` and `http_status=404` if no benchmark run exists for the provided id.
-        """
         parsed = self._parse_operation_run_id(operation_run_id)
         snapshot = self._benchmark_runs().get(parsed)
         if snapshot is None:
@@ -297,23 +233,6 @@ class AdminServices:
         operation_type: OperationRunType,
         parameters: dict[str, object],
     ) -> dict[str, object]:
-        """
-        Start an operation run and enqueue a benchmark run record.
-        
-        Parameters:
-            benchmark_type (BenchmarkRunType): Type of benchmark to queue.
-            operation_type (OperationRunType): OperationRunType used to log and track the enqueueing operation.
-            parameters (dict[str, object]): Parameters to record for the benchmark run.
-        
-        Returns:
-            result (dict[str, object]): Dictionary with keys:
-                - `queued`: `True` if the benchmark run was created.
-                - `operation_run_id`: The operation run identifier (string).
-                - `benchmark`: Serialized benchmark snapshot as a dict.
-        
-        Notes:
-            If an exception occurs while creating the benchmark run, the associated operation run is marked as failed before the exception is re-raised.
-        """
         run_log = self._op_runs().start(operation_type=operation_type, context=dict(parameters))
         try:
             snapshot = self._benchmark_runs().create(
@@ -330,59 +249,7 @@ class AdminServices:
             self._op_runs().fail(UUID(run_log.operation_run_id), error_message=str(exc))
             raise
 
-    @staticmethod
-    def _serialize_app_setting_snapshot(*, snapshot) -> dict[str, object]:  # type: ignore[no-untyped-def]
-        """
-        Serialize an app setting snapshot into a JSON-serializable dictionary that includes metadata about runtime dual-read and sensitivity.
-        
-        Parameters:
-            snapshot: App setting snapshot object containing at minimum `key`, `updated_at`, `updated_by`, `version`, `source`, and `value_json`; the `key` is used to look up the setting definition.
-        
-        Returns:
-            dict[str, object]: Serialized representation with fields:
-              - `key`, `category`, `value_type`, `is_sensitive`
-              - `runtime_dual_read_enabled` (bool), `db_present` (True)
-              - `effective_source` ("db" when runtime dual read is enabled, otherwise None)
-              - `updated_at` (ISO 8601 string), `updated_by`, `version`, `source`
-              - either `value_redacted` (`True`) when the setting is sensitive, or `value_json` containing the setting value when not sensitive.
-        """
-        definition = AppSettingsService.definition_for(snapshot.key)
-        runtime_dual_read_enabled = snapshot.key in RUNTIME_DUAL_READ_KEYS
-        item: dict[str, object] = {
-            "key": snapshot.key,
-            "category": definition.category,
-            "value_type": definition.value_type,
-            "is_sensitive": definition.is_sensitive,
-            "runtime_dual_read_enabled": runtime_dual_read_enabled,
-            "db_present": True,
-            "effective_source": "db" if runtime_dual_read_enabled else None,
-            "updated_at": snapshot.updated_at.isoformat(),
-            "updated_by": snapshot.updated_by,
-            "version": snapshot.version,
-            "source": snapshot.source,
-        }
-        if definition.is_sensitive:
-            item["value_redacted"] = True
-        else:
-            item["value_json"] = dict(snapshot.value_json)
-        return item
-
     def _validate_benchmark_request(self, *, items: int, challenge_word: str | None) -> int:
-        """
-        Validate that benchmark requests are permitted in the current environment and that the requested item count is within allowed limits.
-        
-        Parameters:
-            items (int): Requested number of benchmark items; will be parsed to an int and validated.
-            challenge_word (str | None): Optional challenge string required for permission checks.
-        
-        Returns:
-            int: The parsed and validated number of items to use for the benchmark.
-        
-        Raises:
-            ServiceLayerException: with code "FORBIDDEN_ENV" if the current environment is not allowed;
-            ServiceLayerException: with code "FEATURE_DISABLED" (http 403) if benchmarks are disabled;
-            ServiceLayerException: with code "VALIDATION_ERROR" (http 400) if the challenge is missing/invalid or if `items` is outside the allowed range.
-        """
         env = self._validate_environment()
         if not _flag_enabled("MEDIA_MANAGER_BENCHMARKS_ENABLED"):
             raise ServiceLayerException(

--- a/media_manager/app/service_layer/errors.py
+++ b/media_manager/app/service_layer/errors.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from media_manager.app.core.errors import (
-    AppSettingsValidationError,
-    AppSettingsVersionConflictError,
     MediaManagerError,
     OwnerContextClassificationRequiredError,
     OwnerContextOverrideRequiredError,
@@ -28,20 +26,9 @@ class ServiceLayerException(Exception):
 
 
 def map_exception(exc: Exception) -> ServiceLayerException:
-    """
-    Convert an arbitrary exception into a deterministic ServiceLayerException via type-based mapping.
-    
-    Known validation, version-conflict, owner-context, and domain errors are mapped to standardized service error codes and HTTP statuses; unknown exceptions are mapped to an INTERNAL_ERROR. The original exception message is used for the mapped message, and owner-context errors preserve their `details`.
-    
-    Returns:
-        ServiceLayerException: The corresponding service-layer error with `code`, `message`, `http_status`, and optional `details`.
-    """
+    """Normalize exceptions into deterministic service-layer taxonomy."""
     if isinstance(exc, ServiceLayerException):
         return exc
-    if isinstance(exc, AppSettingsValidationError):
-        return ServiceLayerException(code="VALIDATION_ERROR", message=str(exc), http_status=400)
-    if isinstance(exc, AppSettingsVersionConflictError):
-        return ServiceLayerException(code="STATE_CONFLICT", message=str(exc), http_status=409)
     if isinstance(exc, PolicySettingsValidationError):
         return ServiceLayerException(code="VALIDATION_ERROR", message=str(exc), http_status=400)
     if isinstance(exc, PolicySettingsVersionConflictError):

--- a/operator_console/gui_app/src/lib/api/client.ts
+++ b/operator_console/gui_app/src/lib/api/client.ts
@@ -82,34 +82,9 @@ export async function apiGetJson<T>(
   return (await res.json()) as T;
 }
 
-/**
- * Send a POST request to the API at the given path and parse the service's JSON envelope.
- *
- * @param path - The request path appended to the API base URL (e.g., "/users")
- * @param body - Optional request payload; when provided it is serialized to JSON and sent as the request body
- * @returns The parsed API envelope containing the response data typed as `T`
- */
 export async function apiPost<T>(path: string, body?: unknown): Promise<ApiEnvelope<T>> {
   const res = await fetch(`${API_BASE}${path}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", Accept: "application/json" },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  return parseEnvelope<T>(res);
-}
-
-/**
- * Sends an HTTP PATCH to the API and parses the standardized API envelope response.
- *
- * @param path - Request path appended to the API base URL (e.g., "/users/123")
- * @param body - Optional request payload to be JSON-stringified and sent as the request body
- * @returns The parsed API envelope containing the response data typed as `T`
- *
- * @throws {ApiClientError} When the HTTP response is not OK or the API envelope signals an error
- */
-export async function apiPatch<T>(path: string, body?: unknown): Promise<ApiEnvelope<T>> {
-  const res = await fetch(`${API_BASE}${path}`, {
-    method: "PATCH",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
     body: body ? JSON.stringify(body) : undefined,
   });

--- a/operator_console/gui_app/src/lib/api/endpoints/admin.ts
+++ b/operator_console/gui_app/src/lib/api/endpoints/admin.ts
@@ -1,11 +1,8 @@
-import { apiGet, apiPatch, apiPost } from "@/lib/api/client";
+import { apiGet, apiPost } from "@/lib/api/client";
 import { withData } from "@/lib/api/envelope";
 import { mapObservabilityFailures, mapRunItem } from "@/lib/api/mappers/runs";
 import type {
-  AdminAppSettingPatchPayload,
-  EditableAppSettingKey,
   AppSettingsInspection,
-  AppSettingInspectionItem,
   BenchmarkQueueResult,
   BenchmarkRun,
   DbResetPreview,
@@ -24,9 +21,6 @@ export const adminDbReset = async (params: { dry_run: boolean; challenge_word?: 
 
 export const getAdminAppSettings = async () =>
   apiGet<AppSettingsInspection>("/admin/app-settings");
-
-export const updateAdminAppSetting = async (key: EditableAppSettingKey, payload: AdminAppSettingPatchPayload) =>
-  apiPatch<AppSettingInspectionItem>(`/admin/app-settings/${encodeURIComponent(key)}`, payload);
 
 export const getAdminObservabilitySummary = async () =>
   apiGet<ObservabilitySummary>("/admin/observability/summary");

--- a/operator_console/gui_app/src/pages/AdminPage.tsx
+++ b/operator_console/gui_app/src/pages/AdminPage.tsx
@@ -51,7 +51,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ApiClientError } from "@/lib/api/client";
 import {
   adminDbReset,
   cancelBenchmarkRun,
@@ -75,7 +74,6 @@ import {
   queueDiscoveryBenchmark,
   queueMetadataBenchmark,
   reconcileStaleOperationRuns,
-  updateAdminAppSetting,
   updatePolicy,
 } from "@/lib/api/endpoints";
 import { queryKeys } from "@/lib/api/queryKeys";
@@ -87,7 +85,6 @@ import type {
   BenchmarkRun,
   DbResetPreview,
   DbResetResult,
-  EditableAppSettingKey,
   FailureEventItem,
   HashAuditResult,
   MediaFileRecord,
@@ -122,11 +119,6 @@ const VALID_ADMIN_TABS: AdminTab[] = [
   "reset",
 ];
 const STATUS_EXAMPLES = ["INGESTED", "PROCESSED", "DELETED"] as const;
-const EDITABLE_APP_SETTING_KEYS: readonly EditableAppSettingKey[] = [
-  "video_thumbnails_enabled",
-  "canonical_read_cache_enabled",
-  "canonical_read_cache_ttl_seconds",
-];
 
 const chartConfig = {
   operations: { label: "Operations", color: "hsl(195 85% 42%)" },
@@ -368,12 +360,6 @@ function describeAppSettingRuntime(item: AppSettingInspectionItem) {
   };
 }
 
-/**
- * Produce a short UI-ready description of whether a durable DB row exists for an app setting.
- *
- * @param item - The app setting inspection row to evaluate
- * @returns An object with `label`, `severity`, and `detail` describing the DB presence state
- */
 function describeAppSettingDbState(item: AppSettingInspectionItem) {
   if (!item.db_present) {
     return {
@@ -390,32 +376,6 @@ function describeAppSettingDbState(item: AppSettingInspectionItem) {
   };
 }
 
-/**
- * Determines whether the given app setting key is allowed to be edited in this admin slice.
- *
- * @param key - The app setting key to test
- * @returns `true` if `key` is an editable app setting key (narrows to `EditableAppSettingKey`), `false` otherwise.
- */
-function isEditableAppSettingKey(key: string): key is EditableAppSettingKey {
-  return (EDITABLE_APP_SETTING_KEYS as readonly string[]).includes(key);
-}
-
-/**
- * Extracts the stored durable DB value from an app setting inspection item.
- *
- * @param item - The app setting inspection record to read from
- * @returns The stored value found at `item.value_json.value`, or `undefined` if not present
- */
-function getAppSettingStoredValue(item: AppSettingInspectionItem): unknown {
-  return item.value_json?.value;
-}
-
-/**
- * Render the display cell for an app setting's stored value with sensitive-value handling, a truncated preview, and an optional collapsible JSON viewer.
- *
- * @param item - The app setting inspection item; when `is_sensitive` or `value_redacted` is true a redaction badge and hint are shown, when `db_present` is false or `value_json` is missing a "no durable DB value" hint is shown, otherwise a truncated JSON preview is rendered with a "View JSON" control that expands to show the full stored value.
- * @returns A React element representing the cell content for the app setting value.
- */
 function AppSettingValueCell({ item }: { item: AppSettingInspectionItem }) {
   const [open, setOpen] = useState(false);
 
@@ -2018,23 +1978,9 @@ function IntegrityCheckTab() {
   );
 }
 
-/**
- * Render the System Health admin tab with observability charts, reconciliation tools,
- * recent failure events, operation feed, and an app-settings inspection surface with in-slice editing.
- *
- * The view includes hourly operation/failure charts and a latency trend, a reconcile action to mark stalled runs,
- * a list of recent failure events and runs, external monitoring links, and a table for inspecting (and, for allowed keys, editing)
- * durable app setting rows.
- *
- * @returns The rendered System Health tab as a React element
- */
 function SystemHealthTab() {
   const queryClient = useQueryClient();
   const [includeCurrentDay, setIncludeCurrentDay] = useState(false);
-  const [editingKey, setEditingKey] = useState<EditableAppSettingKey | null>(null);
-  const [editingValue, setEditingValue] = useState<boolean | string>("");
-  const [editingVersion, setEditingVersion] = useState<number | null>(null);
-  const [appSettingEditError, setAppSettingEditError] = useState<string | null>(null);
   const appSettingsQuery = useQuery({
     queryKey: queryKeys.adminAppSettings,
     queryFn: getAdminAppSettings,
@@ -2073,62 +2019,6 @@ function SystemHealthTab() {
       void queryClient.invalidateQueries({ queryKey: queryKeys.runsRoot });
     },
   });
-  const appSettingMutation = useMutation({
-    mutationFn: ({
-      key,
-      value,
-      version,
-    }: {
-      key: EditableAppSettingKey;
-      value: boolean | number;
-      version: number;
-    }) => updateAdminAppSetting(key, { value, version }),
-    onSuccess: (result) => {
-      const updatedItem = result.data as AppSettingInspectionItem;
-      queryClient.setQueryData(queryKeys.adminAppSettings, (current: { data?: AppSettingsInspection } | undefined) => {
-        if (!current?.data?.items) {
-          return current;
-        }
-        return {
-          ...current,
-          data: {
-            ...current.data,
-            items: current.data.items.map((item) => (item.key === updatedItem.key ? updatedItem : item)),
-          },
-        };
-      });
-      setEditingKey(null);
-      setEditingValue("");
-      setEditingVersion(null);
-      setAppSettingEditError(null);
-    },
-    onError: (error) => {
-      setAppSettingEditError(getErrorMessage(error) ?? "Unable to update this app setting.");
-      const status =
-        error instanceof ApiClientError
-          ? error.status
-          : typeof error === "object" && error !== null && "status" in error
-            ? Number((error as { status?: unknown }).status)
-            : undefined;
-      if (status === 409) {
-        void queryClient.invalidateQueries({ queryKey: queryKeys.adminAppSettings }).then(() => {
-          if (!editingKey) return;
-          const refreshed = queryClient.getQueryData<{ data?: AppSettingsInspection }>(queryKeys.adminAppSettings);
-          const refreshedItem = refreshed?.data?.items?.find((item) => item.key === editingKey);
-          if (!refreshedItem || !isEditableAppSettingKey(refreshedItem.key)) return;
-          const storedValue = getAppSettingStoredValue(refreshedItem);
-          setEditingVersion(refreshedItem.version ?? null);
-          setEditingValue(
-            refreshedItem.value_type === "bool"
-              ? Boolean(storedValue)
-              : storedValue == null
-                ? ""
-                : String(storedValue),
-          );
-        });
-      }
-    },
-  });
   const chartRows = useMemo(() => {
     if (!series) return [];
     const operations = new Map(series.series.operation_volume.map((point) => [point.timestamp, point.value]));
@@ -2142,55 +2032,6 @@ function SystemHealthTab() {
       latency: latencyMap.get(point.timestamp) ?? 0,
     }));
   }, [series]);
-
-  function startEditing(item: AppSettingInspectionItem) {
-    if (!isEditableAppSettingKey(item.key)) return;
-    const storedValue = getAppSettingStoredValue(item);
-    setEditingKey(item.key);
-    setEditingVersion(item.version ?? null);
-    setAppSettingEditError(null);
-    if (item.value_type === "bool") {
-      setEditingValue(Boolean(storedValue));
-      return;
-    }
-    setEditingValue(storedValue == null ? "" : String(storedValue));
-  }
-
-  function cancelEditing() {
-    setEditingKey(null);
-    setEditingValue("");
-    setEditingVersion(null);
-    setAppSettingEditError(null);
-  }
-
-  function saveAppSetting(item: AppSettingInspectionItem) {
-    if (!isEditableAppSettingKey(item.key)) return;
-    if (editingVersion == null) {
-      setAppSettingEditError("Unable to update this setting because no current version is available.");
-      return;
-    }
-    let nextValue: boolean | number;
-    if (item.value_type === "bool") {
-      nextValue = Boolean(editingValue);
-    } else {
-      const rawValue = typeof editingValue === "string" ? editingValue.trim() : "";
-      if (!rawValue) {
-        setAppSettingEditError("Enter a value in seconds.");
-        return;
-      }
-      nextValue = Number(rawValue);
-      if (Number.isNaN(nextValue)) {
-        setAppSettingEditError("Enter a valid numeric value in seconds.");
-        return;
-      }
-    }
-    setAppSettingEditError(null);
-    appSettingMutation.mutate({
-      key: item.key,
-      value: nextValue,
-      version: editingVersion,
-    });
-  }
 
   if (summaryQuery.isLoading || runsQuery.isLoading || failuresQuery.isLoading || seriesQuery.isLoading) {
     return <div className="text-sm text-muted-foreground">Loading system health data…</div>;
@@ -2210,7 +2051,6 @@ function SystemHealthTab() {
         <div className="space-y-1">
           <p className="font-mono text-xs font-semibold text-foreground">{item.key}</p>
           <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">{item.category}</p>
-          {isEditableAppSettingKey(item.key) ? <StatusBadge label="Editable in this slice" severity="info" /> : null}
         </div>
       ),
     },
@@ -2251,57 +2091,7 @@ function SystemHealthTab() {
     {
       key: "value",
       header: "Value",
-      render: (item: AppSettingInspectionItem) => {
-        const isEditing = editingKey === item.key && isEditableAppSettingKey(item.key);
-        if (!isEditing) {
-          return <AppSettingValueCell item={item} />;
-        }
-
-        if (item.value_type === "bool") {
-          return (
-            <div className="max-w-[18rem] space-y-3">
-              <div className="flex items-center gap-3">
-                <Switch
-                  checked={Boolean(editingValue)}
-                  onCheckedChange={(checked) => setEditingValue(checked)}
-                  aria-label={`Toggle ${item.key}`}
-                />
-                <span className="text-sm text-foreground">{Boolean(editingValue) ? "Enabled" : "Disabled"}</span>
-              </div>
-              {appSettingEditError ? (
-                <p className="text-xs text-destructive">{appSettingEditError}</p>
-              ) : (
-                <p className="text-xs text-muted-foreground">Boolean value only. Validation remains enforced by the backend.</p>
-              )}
-            </div>
-          );
-        }
-
-        return (
-          <div className="max-w-[18rem] space-y-3">
-            <div className="space-y-2">
-              <Label htmlFor={`app-setting-${item.key}`} className="sr-only">
-                {item.key}
-              </Label>
-              <Input
-                id={`app-setting-${item.key}`}
-                type="number"
-                inputMode="decimal"
-                step="1"
-                min="0"
-                value={String(editingValue)}
-                onChange={(event) => setEditingValue(event.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">seconds</p>
-            </div>
-            {appSettingEditError ? (
-              <p className="text-xs text-destructive">{appSettingEditError}</p>
-            ) : (
-              <p className="text-xs text-muted-foreground">Numeric validation stays server-side for this slice.</p>
-            )}
-          </div>
-        );
-      },
+      render: (item: AppSettingInspectionItem) => <AppSettingValueCell item={item} />,
     },
     {
       key: "updated_at",
@@ -2319,45 +2109,6 @@ function SystemHealthTab() {
             <p className="max-w-[16rem] text-xs text-muted-foreground">
               {metadata.length ? metadata.join(" • ") : "No update metadata recorded."}
             </p>
-          </div>
-        );
-      },
-    },
-    {
-      key: "actions",
-      header: "Actions",
-      render: (item: AppSettingInspectionItem) => {
-        if (!isEditableAppSettingKey(item.key)) {
-          return <StatusBadge label="Inspection only" severity="neutral" />;
-        }
-
-        const isEditing = editingKey === item.key;
-        const isBusy = appSettingMutation.isPending && editingKey === item.key;
-
-        if (!isEditing) {
-          return (
-            <div className="space-y-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => startEditing(item)}
-                disabled={editingKey !== null || appSettingMutation.isPending}
-              >
-                Edit
-              </Button>
-            </div>
-          );
-        }
-
-        return (
-          <div className="flex flex-col gap-2">
-            <Button size="sm" onClick={() => saveAppSetting(item)} disabled={isBusy}>
-              {isBusy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
-              Save
-            </Button>
-            <Button variant="ghost" size="sm" onClick={cancelEditing} disabled={isBusy}>
-              Cancel
-            </Button>
           </div>
         );
       },
@@ -2543,7 +2294,6 @@ function SystemHealthTab() {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="flex flex-wrap gap-2">
-            <StatusBadge label="Editable in this slice" severity="info" />
             <StatusBadge label="Dual-read enabled" severity="success" />
             <StatusBadge label="Inspection only" severity="neutral" />
             <StatusBadge label="Sensitive value redacted" severity="caution" />

--- a/operator_console/gui_app/src/test/admin-page.test.tsx
+++ b/operator_console/gui_app/src/test/admin-page.test.tsx
@@ -34,7 +34,6 @@ const mocks = vi.hoisted(() => ({
   queueDiscoveryBenchmark: vi.fn(),
   queueMetadataBenchmark: vi.fn(),
   reconcileStaleOperationRuns: vi.fn(),
-  updateAdminAppSetting: vi.fn(),
   updatePolicy: vi.fn(),
 }));
 
@@ -61,7 +60,6 @@ vi.mock("@/lib/api/endpoints", () => ({
   queueDiscoveryBenchmark: mocks.queueDiscoveryBenchmark,
   queueMetadataBenchmark: mocks.queueMetadataBenchmark,
   reconcileStaleOperationRuns: mocks.reconcileStaleOperationRuns,
-  updateAdminAppSetting: mocks.updateAdminAppSetting,
   updatePolicy: mocks.updatePolicy,
 }));
 
@@ -262,34 +260,6 @@ describe("Admin page", () => {
             value_json: { value: true },
           },
           {
-            key: "canonical_read_cache_enabled",
-            category: "performance",
-            value_type: "bool",
-            is_sensitive: false,
-            runtime_dual_read_enabled: true,
-            db_present: true,
-            effective_source: "env_fallback",
-            updated_at: "2026-03-20T10:05:00Z",
-            updated_by: "tester",
-            version: 3,
-            source: "admin_ui",
-            value_json: { value: true },
-          },
-          {
-            key: "canonical_read_cache_ttl_seconds",
-            category: "performance",
-            value_type: "float",
-            is_sensitive: false,
-            runtime_dual_read_enabled: true,
-            db_present: true,
-            effective_source: "db",
-            updated_at: "2026-03-20T10:10:00Z",
-            updated_by: "tester",
-            version: 4,
-            source: "admin_ui",
-            value_json: { value: 30 },
-          },
-          {
             key: "directory_picker_enabled",
             category: "ui",
             value_type: "bool",
@@ -464,8 +434,8 @@ describe("Admin page", () => {
     expect(await screen.findByText("App settings inspection")).toBeInTheDocument();
     expect(screen.getByText("video_thumbnails_enabled")).toBeInTheDocument();
     expect(screen.getAllByText("Dual-read enabled").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Runtime source: DB").length).toBeGreaterThan(0);
-    expect(screen.getAllByText('{"value":true}').length).toBeGreaterThan(0);
+    expect(screen.getByText("Runtime source: DB")).toBeInTheDocument();
+    expect(screen.getByText('{"value":true}')).toBeInTheDocument();
   });
 
   it("redacts sensitive app setting values", async () => {
@@ -487,204 +457,7 @@ describe("Admin page", () => {
   it("shows env fallback as the runtime source for dual-read app settings when returned", async () => {
     renderSystemHealthPage();
 
-    expect((await screen.findAllByText("Runtime source: env fallback")).length).toBeGreaterThan(0);
-  });
-
-  it("shows edit controls only for the 3 allowlisted app settings", async () => {
-    renderSystemHealthPage();
-
-    expect(await screen.findByText("video_thumbnails_enabled")).toBeInTheDocument();
-    expect(screen.getAllByText("Editable in this slice")).toHaveLength(4);
-    expect(screen.getAllByRole("button", { name: "Edit" })).toHaveLength(3);
-    expect(screen.queryByRole("button", { name: "Edit directory_picker_enabled" })).not.toBeInTheDocument();
-  });
-
-  it("saves an allowlisted boolean app setting with the correct key and version", async () => {
-    mocks.updateAdminAppSetting.mockResolvedValueOnce({
-      data: {
-        key: "video_thumbnails_enabled",
-        category: "ui",
-        value_type: "bool",
-        is_sensitive: false,
-        runtime_dual_read_enabled: true,
-        db_present: true,
-        effective_source: "db",
-        updated_at: "2026-03-21T10:00:00Z",
-        updated_by: "operator_console:admin",
-        version: 2,
-        source: "admin_ui",
-        value_json: { value: false },
-      },
-    });
-
-    renderSystemHealthPage();
-
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]);
-    fireEvent.click(screen.getByRole("switch", { name: "Toggle video_thumbnails_enabled" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() =>
-      expect(mocks.updateAdminAppSetting).toHaveBeenCalledWith("video_thumbnails_enabled", {
-        value: false,
-        version: 1,
-      }),
-    );
-    expect(await screen.findByText((content) => content.includes('{"value":false}'))).toBeInTheDocument();
-    expect(screen.getByText("by operator_console:admin • v2 • admin_ui")).toBeInTheDocument();
-  });
-
-  it("shows a row-local validation error when an allowlisted update is rejected", async () => {
-    mocks.updateAdminAppSetting.mockRejectedValueOnce(new Error("canonical_read_cache_ttl_seconds must be > 0."));
-
-    renderSystemHealthPage();
-
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[2]);
-    fireEvent.change(screen.getByLabelText("canonical_read_cache_ttl_seconds"), { target: { value: "0" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    expect(
-      await screen.findByText("canonical_read_cache_ttl_seconds must be > 0."),
-    ).toBeInTheDocument();
-  });
-
-  it("shows row-local stale version feedback and refreshes after conflict", async () => {
-    const conflict = new Error("App setting version conflict for canonical_read_cache_enabled: expected 3, got stale.");
-    Object.assign(conflict, { status: 409 });
-    mocks.updateAdminAppSetting.mockRejectedValueOnce(conflict);
-    mocks.getAdminAppSettings.mockReset();
-    mocks.getAdminAppSettings.mockResolvedValueOnce({
-      data: {
-        items: [
-          {
-            key: "video_thumbnails_enabled",
-            category: "ui",
-            value_type: "bool",
-            is_sensitive: false,
-            runtime_dual_read_enabled: true,
-            db_present: true,
-            effective_source: "db",
-            updated_at: "2026-03-20T10:00:00Z",
-            updated_by: "tester",
-            version: 1,
-            source: "bootstrap",
-            value_json: { value: true },
-          },
-          {
-            key: "canonical_read_cache_enabled",
-            category: "performance",
-            value_type: "bool",
-            is_sensitive: false,
-            runtime_dual_read_enabled: true,
-            db_present: true,
-            effective_source: "env_fallback",
-            updated_at: "2026-03-20T10:05:00Z",
-            updated_by: "tester",
-            version: 3,
-            source: "admin_ui",
-            value_json: { value: true },
-          },
-          {
-            key: "canonical_read_cache_ttl_seconds",
-            category: "performance",
-            value_type: "float",
-            is_sensitive: false,
-            runtime_dual_read_enabled: true,
-            db_present: true,
-            effective_source: "db",
-            updated_at: "2026-03-20T10:10:00Z",
-            updated_by: "tester",
-            version: 4,
-            source: "admin_ui",
-            value_json: { value: 30 },
-          },
-          {
-            key: "directory_picker_enabled",
-            category: "ui",
-            value_type: "bool",
-            is_sensitive: false,
-            runtime_dual_read_enabled: false,
-            db_present: false,
-            effective_source: null,
-            updated_at: null,
-            updated_by: null,
-            version: null,
-            source: null,
-          },
-        ],
-      },
-    });
-    mocks.getAdminAppSettings.mockResolvedValueOnce({
-      data: {
-        items: [
-          {
-            key: "video_thumbnails_enabled",
-            category: "ui",
-            value_type: "bool",
-            is_sensitive: false,
-            runtime_dual_read_enabled: true,
-            db_present: true,
-            effective_source: "db",
-            updated_at: "2026-03-20T10:00:00Z",
-            updated_by: "tester",
-            version: 1,
-            source: "bootstrap",
-            value_json: { value: true },
-          },
-          {
-            key: "canonical_read_cache_enabled",
-            category: "performance",
-            value_type: "bool",
-            is_sensitive: false,
-            runtime_dual_read_enabled: true,
-            db_present: true,
-            effective_source: "db",
-            updated_at: "2026-03-21T10:15:00Z",
-            updated_by: "operator_console:admin",
-            version: 4,
-            source: "admin_ui",
-            value_json: { value: false },
-          },
-          {
-            key: "canonical_read_cache_ttl_seconds",
-            category: "performance",
-            value_type: "float",
-            is_sensitive: false,
-            runtime_dual_read_enabled: true,
-            db_present: true,
-            effective_source: "db",
-            updated_at: "2026-03-20T10:10:00Z",
-            updated_by: "tester",
-            version: 4,
-            source: "admin_ui",
-            value_json: { value: 30 },
-          },
-          {
-            key: "directory_picker_enabled",
-            category: "ui",
-            value_type: "bool",
-            is_sensitive: false,
-            runtime_dual_read_enabled: false,
-            db_present: false,
-            effective_source: null,
-            updated_at: null,
-            updated_by: null,
-            version: null,
-            source: null,
-          },
-        ],
-      },
-    });
-
-    renderSystemHealthPage();
-
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[1]);
-    fireEvent.click(screen.getByRole("switch", { name: "Toggle canonical_read_cache_enabled" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    expect(
-      await screen.findByText("App setting version conflict for canonical_read_cache_enabled: expected 3, got stale."),
-    ).toBeInTheDocument();
-    expect(await screen.findByText("by operator_console:admin • v4 • admin_ui")).toBeInTheDocument();
+    expect(await screen.findByText("Runtime source: env fallback")).toBeInTheDocument();
   });
 
   it("shows an empty state when no app settings are returned", async () => {

--- a/operator_console/gui_app/src/test/api-endpoints.test.ts
+++ b/operator_console/gui_app/src/test/api-endpoints.test.ts
@@ -2,11 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/api/client", () => ({
   apiGet: vi.fn(),
-  apiPatch: vi.fn(),
   apiPost: vi.fn(),
 }));
 
-import { apiGet, apiPatch, apiPost } from "@/lib/api/client";
+import { apiGet, apiPost } from "@/lib/api/client";
 import {
   adminDbReset,
   getAdminAppSettings,
@@ -21,7 +20,6 @@ import {
   runIntegrityScan,
   runIngest,
   setDuplicateReclaim,
-  updateAdminAppSetting,
   updatePolicy,
 } from "@/lib/api/endpoints";
 
@@ -110,30 +108,6 @@ describe("api endpoints", () => {
     await getAdminAppSettings();
 
     expect(apiGet).toHaveBeenCalledWith("/admin/app-settings");
-  });
-
-  it("patches allowlisted admin app settings through the API client only", async () => {
-    vi.mocked(apiPatch).mockResolvedValue({
-      ok: true,
-      workflow_version: "v2-service-layer",
-      schema_version: "schema-1",
-      generated_at: "2026-03-14T00:00:00+00:00",
-      data: {
-        key: "video_thumbnails_enabled",
-        value_json: { value: false },
-        version: 2,
-      },
-      errors: [],
-    });
-
-    await updateAdminAppSetting("video_thumbnails_enabled", { value: false, version: 1 });
-
-    expect(apiPatch).toHaveBeenCalledWith("/admin/app-settings/video_thumbnails_enabled", {
-      value: false,
-      version: 1,
-    });
-    expect(apiGet).not.toHaveBeenCalled();
-    expect(apiPost).not.toHaveBeenCalled();
   });
 
   it("derives canonical policy update payloads through the API client only", async () => {

--- a/operator_console/gui_app/src/types/admin.ts
+++ b/operator_console/gui_app/src/types/admin.ts
@@ -21,16 +21,6 @@ export interface AppSettingsInspection {
   items: AppSettingInspectionItem[];
 }
 
-export type EditableAppSettingKey =
-  | "video_thumbnails_enabled"
-  | "canonical_read_cache_enabled"
-  | "canonical_read_cache_ttl_seconds";
-
-export interface AdminAppSettingPatchPayload {
-  value: boolean | number;
-  version: number;
-}
-
 export interface DbResetPreview {
   affected_tables: string[];
   record_counts?: Record<string, number>;

--- a/operator_console/main.py
+++ b/operator_console/main.py
@@ -204,13 +204,6 @@ class MetadataBenchmarkPayload(BaseModel):
     challenge_word: str | None = None
 
 
-class AdminAppSettingPatchPayload(BaseModel):
-    """Payload for narrow allowlisted admin app_settings mutations."""
-
-    value: object
-    version: int
-
-
 class DiscoveryBenchmarkPayload(BaseModel):
     """Payload for admin discovery benchmark queue requests."""
 
@@ -613,14 +606,7 @@ def _parse_discovery_query_args(
 
 
 def create_app() -> FastAPI:
-    """
-    Create and configure the Operator Console FastAPI application.
-    
-    Sets up logging filters, static asset and metrics mounts, startup reconciliation, exception handlers, API routes (read and mutation endpoints), admin routes, and media/thumbnail streaming endpoints used by the Operator Console.
-    
-    Returns:
-        app (FastAPI): A fully configured FastAPI application ready to be served.
-    """
+    """Create and configure the Operator Console FastAPI application."""
     package_root = Path(__file__).parent
     console_static_dir = _resolve_console_static_dir(package_root)
     console_static_index = console_static_dir / "index.html"
@@ -1231,36 +1217,7 @@ def create_app() -> FastAPI:
     def admin_app_settings(
         services: ReadServices = Depends(get_read_services),
     ) -> JSONResponse:
-        """
-        Retrieve operator console administrative application settings.
-        
-        Returns:
-            JSONResponse: A v2 service-envelope whose `data.result` contains the current administrative application settings.
-        """
         return _execute_read("admin-app-settings", services.admin_app_settings)
-
-    @app.patch("/api/admin/app-settings/{key}")
-    def admin_update_app_setting(
-        key: str,
-        payload: AdminAppSettingPatchPayload,
-        services: AdminServices = Depends(get_admin_services),
-    ) -> JSONResponse:
-        """
-        Apply a partial update to an admin application setting identified by `key`.
-        
-        Calls the admin service to update the setting to `payload.value` at `payload.version` and returns the operation result wrapped in the module's v2 service envelope.
-        
-        Parameters:
-            key (str): The settings key to update.
-            payload (AdminAppSettingPatchPayload): Patch payload containing `value` and `version`.
-        
-        Returns:
-            JSONResponse: A v2 service-envelope JSON response containing the update result or error details.
-        """
-        return _execute_mutation(
-            "admin-update-app-setting",
-            lambda: services.update_app_setting(key=key, value=payload.value, version=payload.version),
-        )
 
     @app.get("/api/admin/observability/operation-runs")
     def admin_observability_operation_runs(
@@ -1269,17 +1226,6 @@ def create_app() -> FastAPI:
         status: str | None = Query(default=None),
         services: ReadServices = Depends(get_read_services),
     ) -> JSONResponse:
-        """
-        Return a paginated list of operation runs for observability, optionally filtered by type or status.
-        
-        Parameters:
-            limit (int): Maximum number of items requested; will be clamped to the range 1–200.
-            operation_type (str | None): Optional operation type to filter results.
-            status (str | None): Optional run status to filter results.
-        
-        Returns:
-            JSONResponse: A v2 service-envelope JSON response containing the requested operation run items.
-        """
         parsed_limit = max(1, min(200, int(limit)))
         return _execute_read(
             "admin-observability-operation-runs",

--- a/operator_console/tests/test_main.py
+++ b/operator_console/tests/test_main.py
@@ -55,14 +55,6 @@ def _create_console_client(tmp_path: Path, monkeypatch) -> TestClient:
     return TestClient(create_app())
 
 def test_canonical_api_route_inventory_and_v1_removal() -> None:
-    """
-    Verifies the application's registered routes include the expected canonical API surface and exclude legacy v1 and any /api/v2 routes.
-    
-    Checks performed:
-    - The predefined set of canonical paths is a subset of the application's registered route paths.
-    - The legacy route `/api/v1/ledger/hash-audit` is not present.
-    - No registered route path begins with `/api/v2`.
-    """
     route_paths = {route.path for route in app.routes}
 
     expected_canonical_paths = {
@@ -88,7 +80,6 @@ def test_canonical_api_route_inventory_and_v1_removal() -> None:
         "/api/media-file/validate",
         "/api/admin/hash-audit",
         "/api/admin/db-reset",
-        "/api/admin/app-settings/{key}",
         "/api/admin/operation-runs/reconcile-stale",
         "/api/admin/observability/summary",
         "/api/admin/observability/operation-runs",
@@ -1849,30 +1840,7 @@ class _FakeOperationServices:
 
 
 class _FakeAdminServices:
-    _editable = {
-        "video_thumbnails_enabled": ("ui", "bool"),
-        "canonical_read_cache_enabled": ("performance", "bool"),
-        "canonical_read_cache_ttl_seconds": ("performance", "float"),
-    }
-
     def db_reset(self, *, dry_run: bool, challenge_word: str | None) -> dict[str, object]:
-        """
-        Reset the application's database state or simulate the reset when `dry_run` is true.
-        
-        Parameters:
-            dry_run (bool): If True, no data is deleted and the response describes the simulated effect.
-            challenge_word (str | None): Required when `dry_run` is False; must equal "media-manager" to authorize the reset.
-        
-        Returns:
-            dict[str, object]: Result envelope containing:
-                - "success" (bool): Whether the operation completed.
-                - "dry_run" (bool): Echoes the `dry_run` input.
-                - "affected_tables" (list[str]): Names of tables that would be or were affected.
-                - "message" (str): Human-readable summary of the outcome.
-        
-        Raises:
-            ValueError: If `dry_run` is False and `challenge_word` is not "media-manager".
-        """
         if not dry_run and challenge_word != "media-manager":
             raise ValueError("challenge_word is incorrect.")
         return {
@@ -1883,19 +1851,6 @@ class _FakeAdminServices:
         }
 
     def reconcile_stale_operation_runs(self, *, include_current_day: bool = False) -> dict[str, object]:
-        """
-        Perform a reconciliation of stale operation runs and return a summary of the reconciliation.
-        
-        Parameters:
-        	include_current_day (bool): If True, include operation runs from the current day in the reconciliation; otherwise exclude them.
-        
-        Returns:
-        	result (dict): Summary object containing:
-        		- cutoff (str): ISO 8601 cutoff timestamp used for the reconciliation.
-        		- scanned_count (int): Number of operation runs scanned.
-        		- updated_count (int): Number of operation runs that were updated.
-        		- include_current_day (bool): Echoes the `include_current_day` parameter.
-        """
         return {
             "cutoff": "2026-03-14T00:00:00+00:00" if not include_current_day else "2026-03-14T10:30:00+00:00",
             "scanned_count": 3 if not include_current_day else 5,
@@ -1903,107 +1858,7 @@ class _FakeAdminServices:
             "include_current_day": include_current_day,
         }
 
-    def update_app_setting(self, *, key: str, value: object, version: int) -> dict[str, object]:
-        """
-        Update an editable application setting and return its updated metadata envelope.
-        
-        Parameters:
-            key (str): The setting key to update; must be one of the service's editable keys.
-            value (object): The new value for the setting. Expected types:
-                - "video_thumbnails_enabled": bool
-                - "canonical_read_cache_enabled": bool
-                - "canonical_read_cache_ttl_seconds": positive number (> 0)
-            version (int): The current metadata version from the caller; used for optimistic concurrency.
-        
-        Returns:
-            dict[str, object]: A metadata envelope describing the updated setting, including keys
-            such as `key`, `category`, `value_type`, `version` (incremented), `value_json`, and
-            other audit/runtime fields.
-        
-        Raises:
-            ServiceLayerException: with code "VALIDATION_ERROR" and HTTP 400 when `key` is not editable
-            or when `value` does not match the expected type/constraints; with code "STATE_CONFLICT"
-            and HTTP 409 when the provided `version` does not match the expected current version for
-            the target setting.
-        """
-        if key not in self._editable:
-            raise ServiceLayerException(
-                code="VALIDATION_ERROR",
-                message=f"{key} is not editable in this slice.",
-                http_status=400,
-            )
-
-        if key == "video_thumbnails_enabled":
-            if not isinstance(value, bool):
-                raise ServiceLayerException(
-                    code="VALIDATION_ERROR",
-                    message="video_thumbnails_enabled must be a boolean.",
-                    http_status=400,
-                )
-            if version != 1:
-                raise ServiceLayerException(
-                    code="STATE_CONFLICT",
-                    message="App setting version conflict for video_thumbnails_enabled: expected 1, got stale.",
-                    http_status=409,
-                )
-        elif key == "canonical_read_cache_enabled":
-            if not isinstance(value, bool):
-                raise ServiceLayerException(
-                    code="VALIDATION_ERROR",
-                    message="canonical_read_cache_enabled must be a boolean.",
-                    http_status=400,
-                )
-            if version != 3:
-                raise ServiceLayerException(
-                    code="STATE_CONFLICT",
-                    message="App setting version conflict for canonical_read_cache_enabled: expected 3, got stale.",
-                    http_status=409,
-                )
-        else:
-            if not isinstance(value, (int, float)) or isinstance(value, bool) or float(value) <= 0:
-                raise ServiceLayerException(
-                    code="VALIDATION_ERROR",
-                    message="canonical_read_cache_ttl_seconds must be > 0.",
-                    http_status=400,
-                )
-            if version != 4:
-                raise ServiceLayerException(
-                    code="STATE_CONFLICT",
-                    message="App setting version conflict for canonical_read_cache_ttl_seconds: expected 4, got stale.",
-                    http_status=409,
-                )
-
-        category, value_type = self._editable[key]
-        return {
-            "key": key,
-            "category": category,
-            "value_type": value_type,
-            "is_sensitive": False,
-            "runtime_dual_read_enabled": True,
-            "db_present": True,
-            "effective_source": "db",
-            "updated_at": "2026-03-22T10:00:00+00:00",
-            "updated_by": "operator_console:admin",
-            "version": version + 1,
-            "source": "admin_ui",
-            "value_json": {"value": value},
-        }
-
     def benchmark_metadata_queue(self, *, items: int, batch_size: int, challenge_word: str | None) -> dict[str, object]:
-        """
-        Queue a metadata benchmark run and return a representation of the queued operation.
-        
-        Parameters:
-        	items (int): Number of items to include in the benchmark.
-        	batch_size (int): Batch size to process at a time.
-        	challenge_word (str | None): Must equal "media-manager" to authorize the operation.
-        
-        Returns:
-        	dict[str, object]: A payload describing the queued operation and benchmark run, including `operation_run_id`, `benchmark` metadata, and the provided `items`/`batch_size` parameters.
-        
-        Raises:
-        	ValueError: If `challenge_word` is not "media-manager".
-        """
         if challenge_word != "media-manager":
             raise ValueError("challenge_word is incorrect.")
         return {
@@ -3810,115 +3665,6 @@ def test_admin_app_settings_returns_envelope() -> None:
     assert dual_read["effective_source"] == "db"
     assert non_dual_read["effective_source"] is None
     assert "mutation" not in payload["data"]["result"]
-
-
-def test_patch_admin_app_setting_updates_video_thumbnails_enabled() -> None:
-    app.dependency_overrides[get_admin_services] = _FakeAdminServices
-    client = TestClient(app)
-    try:
-        response = client.patch(
-            "/api/admin/app-settings/video_thumbnails_enabled",
-            json={"value": False, "version": 1},
-        )
-    finally:
-        app.dependency_overrides.clear()
-
-    assert response.status_code == 200
-    payload = response.json()["data"]["result"]
-    assert payload["key"] == "video_thumbnails_enabled"
-    assert payload["value_json"] == {"value": False}
-    assert payload["version"] == 2
-
-
-def test_patch_admin_app_setting_updates_canonical_read_cache_enabled() -> None:
-    app.dependency_overrides[get_admin_services] = _FakeAdminServices
-    client = TestClient(app)
-    try:
-        response = client.patch(
-            "/api/admin/app-settings/canonical_read_cache_enabled",
-            json={"value": False, "version": 3},
-        )
-    finally:
-        app.dependency_overrides.clear()
-
-    assert response.status_code == 200
-    payload = response.json()["data"]["result"]
-    assert payload["key"] == "canonical_read_cache_enabled"
-    assert payload["value_json"] == {"value": False}
-    assert payload["version"] == 4
-
-
-def test_patch_admin_app_setting_updates_canonical_read_cache_ttl_seconds() -> None:
-    """
-    Verifies that PATCH /api/admin/app-settings/canonical_read_cache_ttl_seconds updates the TTL value and increments the stored version.
-    
-    Asserts the endpoint returns 200 and that the response payload's `key` is "canonical_read_cache_ttl_seconds", `value_json` reflects the submitted value, and `version` has been incremented by one.
-    """
-    app.dependency_overrides[get_admin_services] = _FakeAdminServices
-    client = TestClient(app)
-    try:
-        response = client.patch(
-            "/api/admin/app-settings/canonical_read_cache_ttl_seconds",
-            json={"value": 45, "version": 4},
-        )
-    finally:
-        app.dependency_overrides.clear()
-
-    assert response.status_code == 200
-    payload = response.json()["data"]["result"]
-    assert payload["key"] == "canonical_read_cache_ttl_seconds"
-    assert payload["value_json"] == {"value": 45}
-    assert payload["version"] == 5
-
-
-def test_patch_admin_app_setting_rejects_non_allowlisted_key() -> None:
-    app.dependency_overrides[get_admin_services] = _FakeAdminServices
-    client = TestClient(app)
-    try:
-        response = client.patch(
-            "/api/admin/app-settings/directory_picker_enabled",
-            json={"value": True, "version": 1},
-        )
-    finally:
-        app.dependency_overrides.clear()
-
-    assert response.status_code == 400
-    assert "not editable in this slice" in response.json()["errors"][0]["message"].lower()
-
-
-def test_patch_admin_app_setting_returns_validation_error() -> None:
-    app.dependency_overrides[get_admin_services] = _FakeAdminServices
-    client = TestClient(app)
-    try:
-        response = client.patch(
-            "/api/admin/app-settings/canonical_read_cache_ttl_seconds",
-            json={"value": 0, "version": 4},
-        )
-    finally:
-        app.dependency_overrides.clear()
-
-    assert response.status_code == 400
-    assert "must be > 0" in response.json()["errors"][0]["message"]
-
-
-def test_patch_admin_app_setting_returns_version_conflict() -> None:
-    """
-    Verifies that updating an admin app-setting with a stale version returns an HTTP 409 version conflict.
-    
-    This test patches the `canonical_read_cache_enabled` setting with an out-of-date `version` and asserts the response status is 409 and the first error message contains "version conflict".
-    """
-    app.dependency_overrides[get_admin_services] = _FakeAdminServices
-    client = TestClient(app)
-    try:
-        response = client.patch(
-            "/api/admin/app-settings/canonical_read_cache_enabled",
-            json={"value": True, "version": 2},
-        )
-    finally:
-        app.dependency_overrides.clear()
-
-    assert response.status_code == 409
-    assert "version conflict" in response.json()["errors"][0]["message"].lower()
 
 
 def test_admin_observability_failures_returns_envelope() -> None:


### PR DESCRIPTION
## Summary
Revert the unintended app_settings mutation payload that was accidentally merged into `develop` through PR #42.

## Why
PR #42 was intended to be a CI-only chore for `.github/workflows/tests-full.yml`, but the branch was created from the app_settings mutation branch instead of directly from `develop`. As a result, merging PR #42 also brought in the app_settings mutation/backend/frontend changes.

This corrective PR removes that accidental feature payload while preserving the intended `Tests Full` workflow change that was the actual purpose of PR #42.

## Scope
- revert the app_settings mutation/backend/frontend changes that arrived via PR #42
- preserve the `Tests Full` workflow trigger change already merged in PR #42
- do not introduce new behavior beyond restoring the intended branch state

## Notes
- This is a recovery PR for an accidental stacked merge.
- After this lands, the app_settings mutation slice can be reintroduced through its own properly-scoped PR.
