### PR TITLE
[codex] restore narrow editable app settings slice

### DIFF
--- a/media_manager/app/service_layer/admin.py
+++ b/media_manager/app/service_layer/admin.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from sqlalchemy import inspect, text
 
+from media_manager.app.persistence.app_settings import AppSettingsService, RUNTIME_DUAL_READ_KEYS
 from media_manager.app.persistence.base import transactional_session
 from media_manager.app.persistence.benchmark_runs import BenchmarkRunStore
 from media_manager.app.persistence.models import BenchmarkRunType, OperationRunType
@@ -20,6 +21,13 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_CHALLENGE_WORD = "media-manager"
 DEFAULT_BENCHMARK_MAX_ITEMS = 10_000
 DEFAULT_BENCHMARK_METADATA_BATCH_SIZE = 1_000
+EDITABLE_APP_SETTING_KEYS: frozenset[str] = frozenset(
+    {
+        "video_thumbnails_enabled",
+        "canonical_read_cache_enabled",
+        "canonical_read_cache_ttl_seconds",
+    }
+)
 
 # Dependency-safe truncate order (children first, roots last).
 RESET_TABLE_ALLOWLIST: tuple[str, ...] = (
@@ -201,6 +209,31 @@ class AdminServices:
         )
         return result.to_dict()
 
+    def update_app_setting(self, *, key: str, value: object, version: int) -> dict[str, object]:
+        if key not in EDITABLE_APP_SETTING_KEYS:
+            raise ServiceLayerException(
+                code="VALIDATION_ERROR",
+                message=f"{key} is not editable in this slice.",
+                http_status=400,
+            )
+        if key not in RUNTIME_DUAL_READ_KEYS:
+            raise ServiceLayerException(
+                code="VALIDATION_ERROR",
+                message=f"{key} is not runtime-editable in this slice.",
+                http_status=400,
+            )
+
+        service = AppSettingsService(self.session_factory)
+        snapshot = service.set_value(
+            key,
+            value,
+            updated_by="operator_console:admin",
+            source="admin_ui",
+            expected_version=version,
+            reason="allowlisted_admin_update",
+        )
+        return self._serialize_app_setting_snapshot(snapshot=snapshot)
+
     def benchmark_run_detail(self, *, operation_run_id: str) -> dict[str, object]:
         parsed = self._parse_operation_run_id(operation_run_id)
         snapshot = self._benchmark_runs().get(parsed)
@@ -248,6 +281,29 @@ class AdminServices:
         except Exception as exc:
             self._op_runs().fail(UUID(run_log.operation_run_id), error_message=str(exc))
             raise
+
+    @staticmethod
+    def _serialize_app_setting_snapshot(*, snapshot) -> dict[str, object]:  # type: ignore[no-untyped-def]
+        definition = AppSettingsService.definition_for(snapshot.key)
+        runtime_dual_read_enabled = snapshot.key in RUNTIME_DUAL_READ_KEYS
+        item: dict[str, object] = {
+            "key": snapshot.key,
+            "category": definition.category,
+            "value_type": definition.value_type,
+            "is_sensitive": definition.is_sensitive,
+            "runtime_dual_read_enabled": runtime_dual_read_enabled,
+            "db_present": True,
+            "effective_source": "db" if runtime_dual_read_enabled else None,
+            "updated_at": snapshot.updated_at.isoformat(),
+            "updated_by": snapshot.updated_by,
+            "version": snapshot.version,
+            "source": snapshot.source,
+        }
+        if definition.is_sensitive:
+            item["value_redacted"] = True
+        else:
+            item["value_json"] = dict(snapshot.value_json)
+        return item
 
     def _validate_benchmark_request(self, *, items: int, challenge_word: str | None) -> int:
         env = self._validate_environment()

--- a/media_manager/app/service_layer/admin.py
+++ b/media_manager/app/service_layer/admin.py
@@ -291,6 +291,7 @@ class AdminServices:
             "category": definition.category,
             "value_type": definition.value_type,
             "is_sensitive": definition.is_sensitive,
+            "editable_in_slice": snapshot.key in EDITABLE_APP_SETTING_KEYS,
             "runtime_dual_read_enabled": runtime_dual_read_enabled,
             "db_present": True,
             "effective_source": "db" if runtime_dual_read_enabled else None,

--- a/media_manager/app/service_layer/errors.py
+++ b/media_manager/app/service_layer/errors.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from media_manager.app.core.errors import (
+    AppSettingsValidationError,
+    AppSettingsVersionConflictError,
     MediaManagerError,
     OwnerContextClassificationRequiredError,
     OwnerContextOverrideRequiredError,
@@ -29,6 +31,10 @@ def map_exception(exc: Exception) -> ServiceLayerException:
     """Normalize exceptions into deterministic service-layer taxonomy."""
     if isinstance(exc, ServiceLayerException):
         return exc
+    if isinstance(exc, AppSettingsValidationError):
+        return ServiceLayerException(code="VALIDATION_ERROR", message=str(exc), http_status=400)
+    if isinstance(exc, AppSettingsVersionConflictError):
+        return ServiceLayerException(code="STATE_CONFLICT", message=str(exc), http_status=409)
     if isinstance(exc, PolicySettingsValidationError):
         return ServiceLayerException(code="VALIDATION_ERROR", message=str(exc), http_status=400)
     if isinstance(exc, PolicySettingsVersionConflictError):

--- a/media_manager/app/service_layer/reads.py
+++ b/media_manager/app/service_layer/reads.py
@@ -21,6 +21,7 @@ from media_manager.app.persistence.models import (
     TagSource,
 )
 from media_manager.app.persistence.operator_console import OperatorConsoleReadService
+from media_manager.app.service_layer.admin import EDITABLE_APP_SETTING_KEYS
 from media_manager.app.service_layer.cache import ServiceCache
 from media_manager.app.service_layer.versioning import compute_phase_metadata
 
@@ -375,6 +376,7 @@ class ReadServices:
                     "category": definition.category,
                     "value_type": definition.value_type,
                     "is_sensitive": definition.is_sensitive,
+                    "editable_in_slice": key in EDITABLE_APP_SETTING_KEYS,
                     "runtime_dual_read_enabled": runtime_dual_read_enabled,
                     "db_present": db_present,
                     "effective_source": effective_source,

--- a/media_manager/tests/test_service_layer_admin_benchmarks.py
+++ b/media_manager/tests/test_service_layer_admin_benchmarks.py
@@ -4,8 +4,17 @@ from uuid import UUID
 
 from sqlalchemy import select
 
+from media_manager.app.persistence.app_settings import AppSettingsService
 from media_manager.app.persistence.admin_benchmarks import BenchmarkExecutionResult
-from media_manager.app.persistence.models import BenchmarkRun, BenchmarkRunStatus, OperationRun, OperationRunStatus, OperationRunType
+from media_manager.app.core.errors import AppSettingsValidationError, AppSettingsVersionConflictError
+from media_manager.app.persistence.models import (
+    AppSettingHistory,
+    BenchmarkRun,
+    BenchmarkRunStatus,
+    OperationRun,
+    OperationRunStatus,
+    OperationRunType,
+)
 from media_manager.app.service_layer.admin import AdminServices
 from media_manager.app.service_layer.errors import ServiceLayerException
 from media_manager.app.workers import benchmark_runner
@@ -93,3 +102,66 @@ def test_benchmark_worker_processes_queued_job(test_database_url: str, session_f
         assert bench_run is not None
         assert bench_run.status == BenchmarkRunStatus.COMPLETED
         assert bench_run.summary_payload["throughput_files_per_s"] == 123.4
+
+
+def test_update_app_setting_updates_allowlisted_runtime_key(session_factory) -> None:
+    service = AdminServices(session_factory=session_factory)
+    AppSettingsService(session_factory).set_value(
+        "video_thumbnails_enabled",
+        True,
+        updated_by="bootstrap",
+        source="bootstrap",
+        expected_version=0,
+    )
+
+    result = service.update_app_setting(key="video_thumbnails_enabled", value=False, version=1)
+
+    assert result["key"] == "video_thumbnails_enabled"
+    assert result["value_json"] == {"value": False}
+    assert result["updated_by"] == "operator_console:admin"
+    assert result["source"] == "admin_ui"
+    assert result["version"] == 2
+
+    with session_factory() as session:
+        history = session.scalars(
+            select(AppSettingHistory)
+            .where(AppSettingHistory.key == "video_thumbnails_enabled")
+            .order_by(AppSettingHistory.id.asc())
+        ).all()
+
+    assert len(history) == 2
+    assert history[-1].reason == "allowlisted_admin_update"
+
+
+def test_update_app_setting_rejects_non_allowlisted_key(session_factory) -> None:
+    service = AdminServices(session_factory=session_factory)
+
+    try:
+        service.update_app_setting(key="directory_picker_enabled", value=True, version=0)
+        assert False, "expected validation error"
+    except ServiceLayerException as exc:
+        assert exc.http_status == 400
+        assert "not editable in this slice" in exc.message
+
+
+def test_update_app_setting_preserves_validation_and_version_conflict(session_factory) -> None:
+    service = AdminServices(session_factory=session_factory)
+    created = AppSettingsService(session_factory).set_value(
+        "canonical_read_cache_ttl_seconds",
+        30.0,
+        updated_by="bootstrap",
+        source="bootstrap",
+        expected_version=0,
+    )
+
+    try:
+        service.update_app_setting(key="canonical_read_cache_ttl_seconds", value=0, version=created.version)
+        assert False, "expected validation error"
+    except AppSettingsValidationError:
+        pass
+
+    try:
+        service.update_app_setting(key="canonical_read_cache_ttl_seconds", value=45.0, version=created.version - 1)
+        assert False, "expected version conflict"
+    except AppSettingsVersionConflictError:
+        pass

--- a/media_manager/tests/test_service_layer_reads.py
+++ b/media_manager/tests/test_service_layer_reads.py
@@ -55,6 +55,7 @@ def test_admin_app_settings_returns_persisted_non_sensitive_metadata(session_fac
     item = next(entry for entry in payload["items"] if entry["key"] == "video_thumbnails_enabled")
 
     assert item["db_present"] is True
+    assert item["editable_in_slice"] is True
     assert item["runtime_dual_read_enabled"] is True
     assert item["effective_source"] == "db"
     assert item["updated_by"] == "tester"
@@ -70,6 +71,7 @@ def test_admin_app_settings_dual_read_key_without_db_row_uses_env_fallback(sessi
     item = next(entry for entry in payload["items"] if entry["key"] == "benchmark_worker_mode")
 
     assert item["runtime_dual_read_enabled"] is True
+    assert item["editable_in_slice"] is False
     assert item["db_present"] is False
     assert item["effective_source"] == "env_fallback"
     assert item["updated_at"] is None
@@ -85,6 +87,7 @@ def test_admin_app_settings_non_dual_read_key_is_conservative(session_factory) -
     item = next(entry for entry in payload["items"] if entry["key"] == "directory_picker_enabled")
 
     assert item["db_present"] is False
+    assert item["editable_in_slice"] is False
     assert item["runtime_dual_read_enabled"] is False
     assert item["effective_source"] is None
 
@@ -103,6 +106,7 @@ def test_admin_app_settings_sensitive_value_is_redacted(session_factory) -> None
     item = next(entry for entry in payload["items"] if entry["key"] == "db_reset_challenge_word")
 
     assert item["db_present"] is True
+    assert item["editable_in_slice"] is False
     assert item["runtime_dual_read_enabled"] is False
     assert item["effective_source"] is None
     assert item["value_redacted"] is True

--- a/operator_console/gui_app/src/lib/api/client.ts
+++ b/operator_console/gui_app/src/lib/api/client.ts
@@ -86,7 +86,16 @@ export async function apiPost<T>(path: string, body?: unknown): Promise<ApiEnvel
   const res = await fetch(`${API_BASE}${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
-    body: body ? JSON.stringify(body) : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  return parseEnvelope<T>(res);
+}
+
+export async function apiPatch<T>(path: string, body?: unknown): Promise<ApiEnvelope<T>> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
   });
   return parseEnvelope<T>(res);
 }

--- a/operator_console/gui_app/src/lib/api/endpoints/admin.ts
+++ b/operator_console/gui_app/src/lib/api/endpoints/admin.ts
@@ -9,7 +9,6 @@ import type {
   BenchmarkRun,
   DbResetPreview,
   DbResetResult,
-  EditableAppSettingKey,
   ObservabilityMetricsSeries,
   OperationRunReconcileResult,
   ObservabilitySummary,
@@ -25,7 +24,7 @@ export const adminDbReset = async (params: { dry_run: boolean; challenge_word?: 
 export const getAdminAppSettings = async () =>
   apiGet<AppSettingsInspection>("/admin/app-settings");
 
-export const updateAdminAppSetting = async (key: EditableAppSettingKey, payload: AdminAppSettingPatchPayload) =>
+export const updateAdminAppSetting = async (key: string, payload: AdminAppSettingPatchPayload) =>
   apiPatch<AppSettingInspectionItem>(`/admin/app-settings/${encodeURIComponent(key)}`, payload);
 
 export const getAdminObservabilitySummary = async () =>

--- a/operator_console/gui_app/src/lib/api/endpoints/admin.ts
+++ b/operator_console/gui_app/src/lib/api/endpoints/admin.ts
@@ -1,12 +1,15 @@
-import { apiGet, apiPost } from "@/lib/api/client";
+import { apiGet, apiPatch, apiPost } from "@/lib/api/client";
 import { withData } from "@/lib/api/envelope";
 import { mapObservabilityFailures, mapRunItem } from "@/lib/api/mappers/runs";
 import type {
+  AdminAppSettingPatchPayload,
+  AppSettingInspectionItem,
   AppSettingsInspection,
   BenchmarkQueueResult,
   BenchmarkRun,
   DbResetPreview,
   DbResetResult,
+  EditableAppSettingKey,
   ObservabilityMetricsSeries,
   OperationRunReconcileResult,
   ObservabilitySummary,
@@ -21,6 +24,9 @@ export const adminDbReset = async (params: { dry_run: boolean; challenge_word?: 
 
 export const getAdminAppSettings = async () =>
   apiGet<AppSettingsInspection>("/admin/app-settings");
+
+export const updateAdminAppSetting = async (key: EditableAppSettingKey, payload: AdminAppSettingPatchPayload) =>
+  apiPatch<AppSettingInspectionItem>(`/admin/app-settings/${encodeURIComponent(key)}`, payload);
 
 export const getAdminObservabilitySummary = async () =>
   apiGet<ObservabilitySummary>("/admin/observability/summary");

--- a/operator_console/gui_app/src/pages/AdminPage.tsx
+++ b/operator_console/gui_app/src/pages/AdminPage.tsx
@@ -51,6 +51,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ApiClientError } from "@/lib/api/client";
 import {
   adminDbReset,
   cancelBenchmarkRun,
@@ -74,6 +75,7 @@ import {
   queueDiscoveryBenchmark,
   queueMetadataBenchmark,
   reconcileStaleOperationRuns,
+  updateAdminAppSetting,
   updatePolicy,
 } from "@/lib/api/endpoints";
 import { queryKeys } from "@/lib/api/queryKeys";
@@ -85,6 +87,7 @@ import type {
   BenchmarkRun,
   DbResetPreview,
   DbResetResult,
+  EditableAppSettingKey,
   FailureEventItem,
   HashAuditResult,
   MediaFileRecord,
@@ -119,6 +122,11 @@ const VALID_ADMIN_TABS: AdminTab[] = [
   "reset",
 ];
 const STATUS_EXAMPLES = ["INGESTED", "PROCESSED", "DELETED"] as const;
+const EDITABLE_APP_SETTING_KEYS: readonly EditableAppSettingKey[] = [
+  "video_thumbnails_enabled",
+  "canonical_read_cache_enabled",
+  "canonical_read_cache_ttl_seconds",
+];
 
 const chartConfig = {
   operations: { label: "Operations", color: "hsl(195 85% 42%)" },
@@ -374,6 +382,14 @@ function describeAppSettingDbState(item: AppSettingInspectionItem) {
     severity: "success" as const,
     detail: "Durable row available for inspection.",
   };
+}
+
+function isEditableAppSettingKey(key: string): key is EditableAppSettingKey {
+  return (EDITABLE_APP_SETTING_KEYS as readonly string[]).includes(key);
+}
+
+function getAppSettingStoredValue(item: AppSettingInspectionItem): unknown {
+  return item.value_json?.value;
 }
 
 function AppSettingValueCell({ item }: { item: AppSettingInspectionItem }) {
@@ -1981,6 +1997,10 @@ function IntegrityCheckTab() {
 function SystemHealthTab() {
   const queryClient = useQueryClient();
   const [includeCurrentDay, setIncludeCurrentDay] = useState(false);
+  const [editingKey, setEditingKey] = useState<EditableAppSettingKey | null>(null);
+  const [editingValue, setEditingValue] = useState<boolean | string>("");
+  const [editingVersion, setEditingVersion] = useState<number | null>(null);
+  const [appSettingEditError, setAppSettingEditError] = useState<string | null>(null);
   const appSettingsQuery = useQuery({
     queryKey: queryKeys.adminAppSettings,
     queryFn: getAdminAppSettings,
@@ -2019,6 +2039,59 @@ function SystemHealthTab() {
       void queryClient.invalidateQueries({ queryKey: queryKeys.runsRoot });
     },
   });
+  const appSettingMutation = useMutation({
+    mutationFn: ({
+      key,
+      value,
+      version,
+    }: {
+      key: EditableAppSettingKey;
+      value: boolean | number;
+      version: number;
+    }) => updateAdminAppSetting(key, { value, version }),
+    onSuccess: (result) => {
+      const updatedItem = result.data as AppSettingInspectionItem;
+      queryClient.setQueryData(queryKeys.adminAppSettings, (current: { data?: AppSettingsInspection } | undefined) => {
+        if (!current?.data?.items) return current;
+        return {
+          ...current,
+          data: {
+            ...current.data,
+            items: current.data.items.map((item) => (item.key === updatedItem.key ? updatedItem : item)),
+          },
+        };
+      });
+      setEditingKey(null);
+      setEditingValue("");
+      setEditingVersion(null);
+      setAppSettingEditError(null);
+    },
+    onError: (error) => {
+      setAppSettingEditError(getErrorMessage(error) ?? "Unable to update this app setting.");
+      const status =
+        error instanceof ApiClientError
+          ? error.status
+          : typeof error === "object" && error !== null && "status" in error
+            ? Number((error as { status?: unknown }).status)
+            : undefined;
+      if (status === 409 && editingKey) {
+        void queryClient.refetchQueries({ queryKey: queryKeys.adminAppSettings }).then(() => {
+          const refreshed = queryClient.getQueryData<{ data?: AppSettingsInspection }>(queryKeys.adminAppSettings);
+          const refreshedItem = refreshed?.data?.items?.find((item) => item.key === editingKey);
+          if (!refreshedItem || !isEditableAppSettingKey(refreshedItem.key)) return;
+          const storedValue = getAppSettingStoredValue(refreshedItem);
+          setEditingVersion(refreshedItem.version ?? null);
+          setEditingValue(
+            refreshedItem.value_type === "bool"
+              ? Boolean(storedValue)
+              : storedValue == null
+                ? ""
+                : String(storedValue),
+          );
+        });
+      }
+    },
+  });
   const chartRows = useMemo(() => {
     if (!series) return [];
     const operations = new Map(series.series.operation_volume.map((point) => [point.timestamp, point.value]));
@@ -2043,6 +2116,58 @@ function SystemHealthTab() {
   }
 
   const reconcileResult = reconcileMutation.data?.data as OperationRunReconcileResult | undefined;
+
+  function startEditing(item: AppSettingInspectionItem) {
+    if (!isEditableAppSettingKey(item.key)) return;
+    const storedValue = getAppSettingStoredValue(item);
+    setEditingKey(item.key);
+    setEditingVersion(item.version ?? null);
+    setAppSettingEditError(null);
+    if (item.value_type === "bool") {
+      setEditingValue(Boolean(storedValue));
+      return;
+    }
+    setEditingValue(storedValue == null ? "" : String(storedValue));
+  }
+
+  function cancelEditing() {
+    setEditingKey(null);
+    setEditingValue("");
+    setEditingVersion(null);
+    setAppSettingEditError(null);
+  }
+
+  function saveAppSetting(item: AppSettingInspectionItem) {
+    if (!isEditableAppSettingKey(item.key)) return;
+    if (editingVersion == null) {
+      setAppSettingEditError("Unable to update this setting because no current version is available.");
+      return;
+    }
+
+    let nextValue: boolean | number;
+    if (item.value_type === "bool") {
+      nextValue = Boolean(editingValue);
+    } else {
+      const rawValue = typeof editingValue === "string" ? editingValue.trim() : "";
+      if (!rawValue) {
+        setAppSettingEditError("Enter a value.");
+        return;
+      }
+      nextValue = Number(rawValue);
+      if (Number.isNaN(nextValue)) {
+        setAppSettingEditError("Enter a valid numeric value.");
+        return;
+      }
+    }
+
+    setAppSettingEditError(null);
+    appSettingMutation.mutate({
+      key: item.key,
+      value: nextValue,
+      version: editingVersion,
+    });
+  }
+
   const appSettingsColumns = [
     {
       key: "key",
@@ -2051,6 +2176,7 @@ function SystemHealthTab() {
         <div className="space-y-1">
           <p className="font-mono text-xs font-semibold text-foreground">{item.key}</p>
           <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">{item.category}</p>
+          {isEditableAppSettingKey(item.key) ? <StatusBadge label="Editable in this slice" severity="info" /> : null}
         </div>
       ),
     },
@@ -2091,7 +2217,56 @@ function SystemHealthTab() {
     {
       key: "value",
       header: "Value",
-      render: (item: AppSettingInspectionItem) => <AppSettingValueCell item={item} />,
+      render: (item: AppSettingInspectionItem) => {
+        const isEditing = editingKey === item.key && isEditableAppSettingKey(item.key);
+        if (!isEditing) {
+          return <AppSettingValueCell item={item} />;
+        }
+
+        if (item.value_type === "bool") {
+          return (
+            <div className="max-w-[18rem] space-y-3">
+              <div className="flex items-center gap-3">
+                <Switch
+                  checked={Boolean(editingValue)}
+                  onCheckedChange={(checked) => setEditingValue(checked)}
+                  aria-label={`Toggle ${item.key}`}
+                />
+                <span className="text-sm text-foreground">{Boolean(editingValue) ? "Enabled" : "Disabled"}</span>
+              </div>
+              {appSettingEditError ? (
+                <p className="text-xs text-destructive">{appSettingEditError}</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">Validation remains enforced by the backend.</p>
+              )}
+            </div>
+          );
+        }
+
+        return (
+          <div className="max-w-[18rem] space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor={`app-setting-${item.key}`} className="sr-only">
+                {item.key}
+              </Label>
+              <Input
+                id={`app-setting-${item.key}`}
+                type="number"
+                inputMode="decimal"
+                step="any"
+                min="0"
+                value={String(editingValue)}
+                onChange={(event) => setEditingValue(event.target.value)}
+              />
+            </div>
+            {appSettingEditError ? (
+              <p className="text-xs text-destructive">{appSettingEditError}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">Numeric validation stays server-side for this slice.</p>
+            )}
+          </div>
+        );
+      },
     },
     {
       key: "updated_at",
@@ -2109,6 +2284,43 @@ function SystemHealthTab() {
             <p className="max-w-[16rem] text-xs text-muted-foreground">
               {metadata.length ? metadata.join(" • ") : "No update metadata recorded."}
             </p>
+          </div>
+        );
+      },
+    },
+    {
+      key: "actions",
+      header: "Actions",
+      render: (item: AppSettingInspectionItem) => {
+        if (!isEditableAppSettingKey(item.key)) {
+          return <StatusBadge label="Inspection only" severity="neutral" />;
+        }
+
+        const isEditing = editingKey === item.key;
+        const isBusy = appSettingMutation.isPending && editingKey === item.key;
+
+        if (!isEditing) {
+          return (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => startEditing(item)}
+              disabled={editingKey !== null || appSettingMutation.isPending}
+            >
+              Edit
+            </Button>
+          );
+        }
+
+        return (
+          <div className="flex flex-col gap-2">
+            <Button size="sm" onClick={() => saveAppSetting(item)} disabled={isBusy}>
+              {isBusy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
+              Save
+            </Button>
+            <Button variant="ghost" size="sm" onClick={cancelEditing} disabled={isBusy}>
+              Cancel
+            </Button>
           </div>
         );
       },
@@ -2294,6 +2506,7 @@ function SystemHealthTab() {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="flex flex-wrap gap-2">
+            <StatusBadge label="Editable in this slice" severity="info" />
             <StatusBadge label="Dual-read enabled" severity="success" />
             <StatusBadge label="Inspection only" severity="neutral" />
             <StatusBadge label="Sensitive value redacted" severity="caution" />

--- a/operator_console/gui_app/src/pages/AdminPage.tsx
+++ b/operator_console/gui_app/src/pages/AdminPage.tsx
@@ -87,7 +87,6 @@ import type {
   BenchmarkRun,
   DbResetPreview,
   DbResetResult,
-  EditableAppSettingKey,
   FailureEventItem,
   HashAuditResult,
   MediaFileRecord,
@@ -122,11 +121,6 @@ const VALID_ADMIN_TABS: AdminTab[] = [
   "reset",
 ];
 const STATUS_EXAMPLES = ["INGESTED", "PROCESSED", "DELETED"] as const;
-const EDITABLE_APP_SETTING_KEYS: readonly EditableAppSettingKey[] = [
-  "video_thumbnails_enabled",
-  "canonical_read_cache_enabled",
-  "canonical_read_cache_ttl_seconds",
-];
 
 const chartConfig = {
   operations: { label: "Operations", color: "hsl(195 85% 42%)" },
@@ -384,8 +378,8 @@ function describeAppSettingDbState(item: AppSettingInspectionItem) {
   };
 }
 
-function isEditableAppSettingKey(key: string): key is EditableAppSettingKey {
-  return (EDITABLE_APP_SETTING_KEYS as readonly string[]).includes(key);
+function isEditableAppSetting(item: AppSettingInspectionItem): boolean {
+  return item.editable_in_slice;
 }
 
 function getAppSettingStoredValue(item: AppSettingInspectionItem): unknown {
@@ -1997,7 +1991,7 @@ function IntegrityCheckTab() {
 function SystemHealthTab() {
   const queryClient = useQueryClient();
   const [includeCurrentDay, setIncludeCurrentDay] = useState(false);
-  const [editingKey, setEditingKey] = useState<EditableAppSettingKey | null>(null);
+  const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState<boolean | string>("");
   const [editingVersion, setEditingVersion] = useState<number | null>(null);
   const [appSettingEditError, setAppSettingEditError] = useState<string | null>(null);
@@ -2045,7 +2039,7 @@ function SystemHealthTab() {
       value,
       version,
     }: {
-      key: EditableAppSettingKey;
+      key: string;
       value: boolean | number;
       version: number;
     }) => updateAdminAppSetting(key, { value, version }),
@@ -2078,7 +2072,7 @@ function SystemHealthTab() {
         void queryClient.refetchQueries({ queryKey: queryKeys.adminAppSettings }).then(() => {
           const refreshed = queryClient.getQueryData<{ data?: AppSettingsInspection }>(queryKeys.adminAppSettings);
           const refreshedItem = refreshed?.data?.items?.find((item) => item.key === editingKey);
-          if (!refreshedItem || !isEditableAppSettingKey(refreshedItem.key)) return;
+          if (!refreshedItem || !isEditableAppSetting(refreshedItem)) return;
           const storedValue = getAppSettingStoredValue(refreshedItem);
           setEditingVersion(refreshedItem.version ?? null);
           setEditingValue(
@@ -2118,10 +2112,10 @@ function SystemHealthTab() {
   const reconcileResult = reconcileMutation.data?.data as OperationRunReconcileResult | undefined;
 
   function startEditing(item: AppSettingInspectionItem) {
-    if (!isEditableAppSettingKey(item.key)) return;
+    if (!isEditableAppSetting(item)) return;
     const storedValue = getAppSettingStoredValue(item);
     setEditingKey(item.key);
-    setEditingVersion(item.version ?? null);
+    setEditingVersion(item.version ?? 0);
     setAppSettingEditError(null);
     if (item.value_type === "bool") {
       setEditingValue(Boolean(storedValue));
@@ -2138,11 +2132,8 @@ function SystemHealthTab() {
   }
 
   function saveAppSetting(item: AppSettingInspectionItem) {
-    if (!isEditableAppSettingKey(item.key)) return;
-    if (editingVersion == null) {
-      setAppSettingEditError("Unable to update this setting because no current version is available.");
-      return;
-    }
+    if (!isEditableAppSetting(item)) return;
+    const expectedVersion = editingVersion ?? 0;
 
     let nextValue: boolean | number;
     if (item.value_type === "bool") {
@@ -2164,7 +2155,7 @@ function SystemHealthTab() {
     appSettingMutation.mutate({
       key: item.key,
       value: nextValue,
-      version: editingVersion,
+      version: expectedVersion,
     });
   }
 
@@ -2176,7 +2167,7 @@ function SystemHealthTab() {
         <div className="space-y-1">
           <p className="font-mono text-xs font-semibold text-foreground">{item.key}</p>
           <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">{item.category}</p>
-          {isEditableAppSettingKey(item.key) ? <StatusBadge label="Editable in this slice" severity="info" /> : null}
+          {isEditableAppSetting(item) ? <StatusBadge label="Editable in this slice" severity="info" /> : null}
         </div>
       ),
     },
@@ -2218,7 +2209,7 @@ function SystemHealthTab() {
       key: "value",
       header: "Value",
       render: (item: AppSettingInspectionItem) => {
-        const isEditing = editingKey === item.key && isEditableAppSettingKey(item.key);
+        const isEditing = editingKey === item.key && isEditableAppSetting(item);
         if (!isEditing) {
           return <AppSettingValueCell item={item} />;
         }
@@ -2292,7 +2283,7 @@ function SystemHealthTab() {
       key: "actions",
       header: "Actions",
       render: (item: AppSettingInspectionItem) => {
-        if (!isEditableAppSettingKey(item.key)) {
+        if (!isEditableAppSetting(item)) {
           return <StatusBadge label="Inspection only" severity="neutral" />;
         }
 

--- a/operator_console/gui_app/src/test/admin-page.test.tsx
+++ b/operator_console/gui_app/src/test/admin-page.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { ApiClientError } from "@/lib/api/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   queueDiscoveryBenchmark: vi.fn(),
   queueMetadataBenchmark: vi.fn(),
   reconcileStaleOperationRuns: vi.fn(),
+  updateAdminAppSetting: vi.fn(),
   updatePolicy: vi.fn(),
 }));
 
@@ -60,6 +62,7 @@ vi.mock("@/lib/api/endpoints", () => ({
   queueDiscoveryBenchmark: mocks.queueDiscoveryBenchmark,
   queueMetadataBenchmark: mocks.queueMetadataBenchmark,
   reconcileStaleOperationRuns: mocks.reconcileStaleOperationRuns,
+  updateAdminAppSetting: mocks.updateAdminAppSetting,
   updatePolicy: mocks.updatePolicy,
 }));
 
@@ -260,6 +263,34 @@ describe("Admin page", () => {
             value_json: { value: true },
           },
           {
+            key: "canonical_read_cache_enabled",
+            category: "performance",
+            value_type: "bool",
+            is_sensitive: false,
+            runtime_dual_read_enabled: true,
+            db_present: true,
+            effective_source: "db",
+            updated_at: "2026-03-20T10:30:00Z",
+            updated_by: "tester",
+            version: 3,
+            source: "bootstrap",
+            value_json: { value: true },
+          },
+          {
+            key: "canonical_read_cache_ttl_seconds",
+            category: "performance",
+            value_type: "float",
+            is_sensitive: false,
+            runtime_dual_read_enabled: true,
+            db_present: true,
+            effective_source: "db",
+            updated_at: "2026-03-20T10:45:00Z",
+            updated_by: "tester",
+            version: 4,
+            source: "bootstrap",
+            value_json: { value: 30.0 },
+          },
+          {
             key: "directory_picker_enabled",
             category: "ui",
             value_type: "bool",
@@ -434,8 +465,8 @@ describe("Admin page", () => {
     expect(await screen.findByText("App settings inspection")).toBeInTheDocument();
     expect(screen.getByText("video_thumbnails_enabled")).toBeInTheDocument();
     expect(screen.getAllByText("Dual-read enabled").length).toBeGreaterThan(0);
-    expect(screen.getByText("Runtime source: DB")).toBeInTheDocument();
-    expect(screen.getByText('{"value":true}')).toBeInTheDocument();
+    expect(screen.getAllByText("Runtime source: DB").length).toBeGreaterThan(0);
+    expect(screen.getAllByText('{"value":true}').length).toBeGreaterThan(0);
   });
 
   it("redacts sensitive app setting values", async () => {
@@ -448,10 +479,83 @@ describe("Admin page", () => {
   it("labels non-dual-read app settings as inspection only", async () => {
     renderSystemHealthPage();
 
-    expect(await screen.findByText("directory_picker_enabled")).toBeInTheDocument();
-    expect(screen.getAllByText("Inspection only").length).toBeGreaterThan(0);
+    const row = (await screen.findByText("directory_picker_enabled")).closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(within(row as HTMLElement).getAllByText("Inspection only").length).toBeGreaterThan(0);
     expect(screen.getByText("DB presence does not make this an active runtime authority.")).toBeInTheDocument();
     expect(screen.getByText("No DB value")).toBeInTheDocument();
+  });
+
+  it("shows edit controls for the narrow allowlisted app settings only", async () => {
+    renderSystemHealthPage();
+
+    expect(await screen.findByText("video_thumbnails_enabled")).toBeInTheDocument();
+    expect(screen.getAllByText("Editable in this slice").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Edit" }).length).toBe(3);
+  });
+
+  it("saves an allowlisted boolean app setting", async () => {
+    mocks.updateAdminAppSetting.mockResolvedValue({
+      data: {
+        key: "video_thumbnails_enabled",
+        category: "ui",
+        value_type: "bool",
+        is_sensitive: false,
+        runtime_dual_read_enabled: true,
+        db_present: true,
+        effective_source: "db",
+        updated_at: "2026-03-20T12:00:00Z",
+        updated_by: "operator_console:admin",
+        version: 2,
+        source: "admin_ui",
+        value_json: { value: false },
+      },
+    });
+
+    renderSystemHealthPage();
+
+    const row = (await screen.findByText("video_thumbnails_enabled")).closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.click(within(row as HTMLElement).getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("switch", { name: "Toggle video_thumbnails_enabled" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mocks.updateAdminAppSetting).toHaveBeenCalledWith("video_thumbnails_enabled", {
+        value: false,
+        version: 1,
+      }),
+    );
+    expect(await screen.findByText('{"value":false}')).toBeInTheDocument();
+  });
+
+  it("shows backend validation failures while editing an allowlisted numeric app setting", async () => {
+    mocks.updateAdminAppSetting.mockRejectedValueOnce(new ApiClientError("must be > 0", 400));
+
+    renderSystemHealthPage();
+
+    const ttlRow = (await screen.findByText("canonical_read_cache_ttl_seconds")).closest("tr");
+    expect(ttlRow).not.toBeNull();
+    fireEvent.click(within(ttlRow as HTMLElement).getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByLabelText("canonical_read_cache_ttl_seconds"), { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("must be > 0")).toBeInTheDocument();
+  });
+
+  it("keeps version conflict behavior visible for app setting edits", async () => {
+    mocks.updateAdminAppSetting.mockRejectedValueOnce(new ApiClientError("version conflict", 409));
+
+    renderSystemHealthPage();
+
+    const row = (await screen.findByText("video_thumbnails_enabled")).closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.click(within(row as HTMLElement).getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("version conflict")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getAdminAppSettings).toHaveBeenCalledTimes(2));
   });
 
   it("shows env fallback as the runtime source for dual-read app settings when returned", async () => {

--- a/operator_console/gui_app/src/test/admin-page.test.tsx
+++ b/operator_console/gui_app/src/test/admin-page.test.tsx
@@ -253,6 +253,7 @@ describe("Admin page", () => {
             category: "ui",
             value_type: "bool",
             is_sensitive: false,
+            editable_in_slice: true,
             runtime_dual_read_enabled: true,
             db_present: true,
             effective_source: "db",
@@ -267,6 +268,7 @@ describe("Admin page", () => {
             category: "performance",
             value_type: "bool",
             is_sensitive: false,
+            editable_in_slice: true,
             runtime_dual_read_enabled: true,
             db_present: true,
             effective_source: "db",
@@ -281,6 +283,7 @@ describe("Admin page", () => {
             category: "performance",
             value_type: "float",
             is_sensitive: false,
+            editable_in_slice: true,
             runtime_dual_read_enabled: true,
             db_present: true,
             effective_source: "db",
@@ -295,6 +298,7 @@ describe("Admin page", () => {
             category: "ui",
             value_type: "bool",
             is_sensitive: false,
+            editable_in_slice: false,
             runtime_dual_read_enabled: false,
             db_present: false,
             effective_source: null,
@@ -308,6 +312,7 @@ describe("Admin page", () => {
             category: "admin_safety",
             value_type: "string",
             is_sensitive: true,
+            editable_in_slice: false,
             runtime_dual_read_enabled: true,
             db_present: true,
             effective_source: "env_fallback",
@@ -502,6 +507,7 @@ describe("Admin page", () => {
         category: "ui",
         value_type: "bool",
         is_sensitive: false,
+        editable_in_slice: true,
         runtime_dual_read_enabled: true,
         db_present: true,
         effective_source: "db",
@@ -528,6 +534,60 @@ describe("Admin page", () => {
       }),
     );
     expect(await screen.findByText('{"value":false}')).toBeInTheDocument();
+  });
+
+  it("uses version 0 for first-write edits when no durable row exists yet", async () => {
+    mocks.getAdminAppSettings.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            key: "video_thumbnails_enabled",
+            category: "ui",
+            value_type: "bool",
+            is_sensitive: false,
+            editable_in_slice: true,
+            runtime_dual_read_enabled: true,
+            db_present: false,
+            effective_source: "env_fallback",
+            updated_at: null,
+            updated_by: null,
+            version: null,
+            source: null,
+          },
+        ],
+      },
+    });
+    mocks.updateAdminAppSetting.mockResolvedValueOnce({
+      data: {
+        key: "video_thumbnails_enabled",
+        category: "ui",
+        value_type: "bool",
+        is_sensitive: false,
+        editable_in_slice: true,
+        runtime_dual_read_enabled: true,
+        db_present: true,
+        effective_source: "db",
+        updated_at: "2026-03-20T12:00:00Z",
+        updated_by: "operator_console:admin",
+        version: 1,
+        source: "admin_ui",
+        value_json: { value: true },
+      },
+    });
+
+    renderSystemHealthPage();
+
+    const row = (await screen.findByText("video_thumbnails_enabled")).closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.click(within(row as HTMLElement).getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mocks.updateAdminAppSetting).toHaveBeenCalledWith("video_thumbnails_enabled", {
+        value: false,
+        version: 0,
+      }),
+    );
   });
 
   it("shows backend validation failures while editing an allowlisted numeric app setting", async () => {

--- a/operator_console/gui_app/src/test/api-client.test.ts
+++ b/operator_console/gui_app/src/test/api-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ApiClientError, apiGet, apiPost } from "@/lib/api/client";
+import { ApiClientError, apiGet, apiPatch, apiPost } from "@/lib/api/client";
 
 describe("api client", () => {
   afterEach(() => {
@@ -122,6 +122,30 @@ describe("api client", () => {
       name: "ApiClientError",
       message: "version conflict",
       status: 409,
+    });
+  });
+
+  it("serializes falsy PATCH values instead of dropping the body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        workflow_version: "v2-service-layer",
+        schema_version: "schema-1",
+        generated_at: "2026-03-14T00:00:00+00:00",
+        data: { result: { value_json: { value: false } } },
+        errors: [],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiPatch("/admin/app-settings/video_thumbnails_enabled", { value: false, version: 1 });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/admin/app-settings/video_thumbnails_enabled", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ value: false, version: 1 }),
     });
   });
 });

--- a/operator_console/gui_app/src/test/api-endpoints.test.ts
+++ b/operator_console/gui_app/src/test/api-endpoints.test.ts
@@ -2,10 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/api/client", () => ({
   apiGet: vi.fn(),
+  apiPatch: vi.fn(),
   apiPost: vi.fn(),
 }));
 
-import { apiGet, apiPost } from "@/lib/api/client";
+import { apiGet, apiPatch, apiPost } from "@/lib/api/client";
 import {
   adminDbReset,
   getAdminAppSettings,
@@ -20,6 +21,7 @@ import {
   runIntegrityScan,
   runIngest,
   setDuplicateReclaim,
+  updateAdminAppSetting,
   updatePolicy,
 } from "@/lib/api/endpoints";
 
@@ -108,6 +110,27 @@ describe("api endpoints", () => {
     await getAdminAppSettings();
 
     expect(apiGet).toHaveBeenCalledWith("/admin/app-settings");
+  });
+
+  it("routes allowlisted admin app setting updates through PATCH only", async () => {
+    vi.mocked(apiPatch).mockResolvedValue({
+      ok: true,
+      workflow_version: "v2-service-layer",
+      schema_version: "schema-1",
+      generated_at: "2026-03-14T00:00:00+00:00",
+      data: {
+        key: "video_thumbnails_enabled",
+        value_json: { value: false },
+      },
+      errors: [],
+    });
+
+    await updateAdminAppSetting("video_thumbnails_enabled", { value: false, version: 1 });
+
+    expect(apiPatch).toHaveBeenCalledWith("/admin/app-settings/video_thumbnails_enabled", {
+      value: false,
+      version: 1,
+    });
   });
 
   it("derives canonical policy update payloads through the API client only", async () => {

--- a/operator_console/gui_app/src/types/admin.ts
+++ b/operator_console/gui_app/src/types/admin.ts
@@ -1,11 +1,6 @@
 import type { LatestMetrics } from "@/types/dashboard";
 import type { Run } from "@/types/runs";
 
-export type EditableAppSettingKey =
-  | "video_thumbnails_enabled"
-  | "canonical_read_cache_enabled"
-  | "canonical_read_cache_ttl_seconds";
-
 export interface AdminAppSettingPatchPayload {
   value: boolean | number;
   version: number;
@@ -16,6 +11,7 @@ export interface AppSettingInspectionItem {
   category: string;
   value_type: string;
   is_sensitive: boolean;
+  editable_in_slice: boolean;
   runtime_dual_read_enabled: boolean;
   db_present: boolean;
   effective_source: "db" | "env_fallback" | null;

--- a/operator_console/gui_app/src/types/admin.ts
+++ b/operator_console/gui_app/src/types/admin.ts
@@ -1,6 +1,16 @@
 import type { LatestMetrics } from "@/types/dashboard";
 import type { Run } from "@/types/runs";
 
+export type EditableAppSettingKey =
+  | "video_thumbnails_enabled"
+  | "canonical_read_cache_enabled"
+  | "canonical_read_cache_ttl_seconds";
+
+export interface AdminAppSettingPatchPayload {
+  value: boolean | number;
+  version: number;
+}
+
 export interface AppSettingInspectionItem {
   key: string;
   category: string;

--- a/operator_console/main.py
+++ b/operator_console/main.py
@@ -204,6 +204,13 @@ class MetadataBenchmarkPayload(BaseModel):
     challenge_word: str | None = None
 
 
+class AdminAppSettingPatchPayload(BaseModel):
+    """Payload for the narrow editable app_settings admin slice."""
+
+    value: object
+    version: int
+
+
 class DiscoveryBenchmarkPayload(BaseModel):
     """Payload for admin discovery benchmark queue requests."""
 
@@ -1218,6 +1225,17 @@ def create_app() -> FastAPI:
         services: ReadServices = Depends(get_read_services),
     ) -> JSONResponse:
         return _execute_read("admin-app-settings", services.admin_app_settings)
+
+    @app.patch("/api/admin/app-settings/{key}")
+    def admin_update_app_setting(
+        key: str,
+        payload: AdminAppSettingPatchPayload,
+        services: AdminServices = Depends(get_admin_services),
+    ) -> JSONResponse:
+        return _execute_mutation(
+            "admin-update-app-setting",
+            lambda: services.update_app_setting(key=key, value=payload.value, version=payload.version),
+        )
 
     @app.get("/api/admin/observability/operation-runs")
     def admin_observability_operation_runs(

--- a/operator_console/tests/test_main.py
+++ b/operator_console/tests/test_main.py
@@ -1273,6 +1273,7 @@ class _FakeReadServices:
                     "category": "ui",
                     "value_type": "bool",
                     "is_sensitive": False,
+                    "editable_in_slice": True,
                     "runtime_dual_read_enabled": True,
                     "db_present": True,
                     "effective_source": "db",
@@ -1287,6 +1288,7 @@ class _FakeReadServices:
                     "category": "ui",
                     "value_type": "bool",
                     "is_sensitive": False,
+                    "editable_in_slice": False,
                     "runtime_dual_read_enabled": False,
                     "db_present": False,
                     "effective_source": None,
@@ -1902,6 +1904,7 @@ class _FakeAdminServices:
             "category": category,
             "value_type": value_type,
             "is_sensitive": False,
+            "editable_in_slice": True,
             "runtime_dual_read_enabled": True,
             "db_present": True,
             "effective_source": "db",
@@ -3716,6 +3719,8 @@ def test_admin_app_settings_returns_envelope() -> None:
     items = payload["data"]["result"]["items"]
     dual_read = next(item for item in items if item["key"] == "video_thumbnails_enabled")
     non_dual_read = next(item for item in items if item["key"] == "directory_picker_enabled")
+    assert dual_read["editable_in_slice"] is True
+    assert non_dual_read["editable_in_slice"] is False
     assert dual_read["effective_source"] == "db"
     assert non_dual_read["effective_source"] is None
     assert "mutation" not in payload["data"]["result"]

--- a/operator_console/tests/test_main.py
+++ b/operator_console/tests/test_main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 from uuid import UUID
 
 from fastapi.testclient import TestClient
@@ -80,6 +80,7 @@ def test_canonical_api_route_inventory_and_v1_removal() -> None:
         "/api/media-file/validate",
         "/api/admin/hash-audit",
         "/api/admin/db-reset",
+        "/api/admin/app-settings/{key}",
         "/api/admin/operation-runs/reconcile-stale",
         "/api/admin/observability/summary",
         "/api/admin/observability/operation-runs",
@@ -1840,6 +1841,12 @@ class _FakeOperationServices:
 
 
 class _FakeAdminServices:
+    _editable: ClassVar[dict[str, tuple[str, str, int]]] = {
+        "video_thumbnails_enabled": ("ui", "bool", 1),
+        "canonical_read_cache_enabled": ("performance", "bool", 3),
+        "canonical_read_cache_ttl_seconds": ("performance", "float", 4),
+    }
+
     def db_reset(self, *, dry_run: bool, challenge_word: str | None) -> dict[str, object]:
         if not dry_run and challenge_word != "media-manager":
             raise ValueError("challenge_word is incorrect.")
@@ -1856,6 +1863,53 @@ class _FakeAdminServices:
             "scanned_count": 3 if not include_current_day else 5,
             "updated_count": 2 if not include_current_day else 4,
             "include_current_day": include_current_day,
+        }
+
+    def update_app_setting(self, *, key: str, value: object, version: int) -> dict[str, object]:
+        editable = self._editable.get(key)
+        if editable is None:
+            raise ServiceLayerException(
+                code="VALIDATION_ERROR",
+                message=f"{key} is not editable in this slice.",
+                http_status=400,
+            )
+
+        category, value_type, expected_version = editable
+        if version != expected_version:
+            raise ServiceLayerException(
+                code="STATE_CONFLICT",
+                message=f"App setting version conflict for {key}: expected {expected_version}, got stale.",
+                http_status=409,
+            )
+
+        if value_type == "bool":
+            if not isinstance(value, bool):
+                raise ServiceLayerException(
+                    code="VALIDATION_ERROR",
+                    message=f"{key} must be a boolean.",
+                    http_status=400,
+                )
+        else:
+            if not isinstance(value, (int, float)) or isinstance(value, bool) or float(value) <= 0:
+                raise ServiceLayerException(
+                    code="VALIDATION_ERROR",
+                    message=f"{key} must be > 0.",
+                    http_status=400,
+                )
+
+        return {
+            "key": key,
+            "category": category,
+            "value_type": value_type,
+            "is_sensitive": False,
+            "runtime_dual_read_enabled": True,
+            "db_present": True,
+            "effective_source": "db",
+            "updated_at": "2026-03-22T10:00:00+00:00",
+            "updated_by": "operator_console:admin",
+            "version": version + 1,
+            "source": "admin_ui",
+            "value_json": {"value": value},
         }
 
     def benchmark_metadata_queue(self, *, items: int, batch_size: int, challenge_word: str | None) -> dict[str, object]:
@@ -3665,6 +3719,65 @@ def test_admin_app_settings_returns_envelope() -> None:
     assert dual_read["effective_source"] == "db"
     assert non_dual_read["effective_source"] is None
     assert "mutation" not in payload["data"]["result"]
+
+
+def test_patch_admin_app_setting_updates_video_thumbnails_enabled() -> None:
+    app.dependency_overrides[get_admin_services] = _FakeAdminServices
+    client = TestClient(app)
+    try:
+        response = client.patch(
+            "/api/admin/app-settings/video_thumbnails_enabled",
+            json={"value": False, "version": 1},
+        )
+    finally:
+        app.dependency_overrides.clear()
+    assert response.status_code == 200
+    payload = response.json()["data"]["result"]
+    assert payload["key"] == "video_thumbnails_enabled"
+    assert payload["value_json"] == {"value": False}
+    assert payload["version"] == 2
+
+
+def test_patch_admin_app_setting_rejects_non_allowlisted_key() -> None:
+    app.dependency_overrides[get_admin_services] = _FakeAdminServices
+    client = TestClient(app)
+    try:
+        response = client.patch(
+            "/api/admin/app-settings/directory_picker_enabled",
+            json={"value": True, "version": 1},
+        )
+    finally:
+        app.dependency_overrides.clear()
+    assert response.status_code == 400
+    assert "not editable in this slice" in response.json()["errors"][0]["message"].lower()
+
+
+def test_patch_admin_app_setting_returns_validation_error() -> None:
+    app.dependency_overrides[get_admin_services] = _FakeAdminServices
+    client = TestClient(app)
+    try:
+        response = client.patch(
+            "/api/admin/app-settings/canonical_read_cache_ttl_seconds",
+            json={"value": 0, "version": 4},
+        )
+    finally:
+        app.dependency_overrides.clear()
+    assert response.status_code == 400
+    assert "must be > 0" in response.json()["errors"][0]["message"]
+
+
+def test_patch_admin_app_setting_returns_version_conflict() -> None:
+    app.dependency_overrides[get_admin_services] = _FakeAdminServices
+    client = TestClient(app)
+    try:
+        response = client.patch(
+            "/api/admin/app-settings/canonical_read_cache_enabled",
+            json={"value": True, "version": 2},
+        )
+    finally:
+        app.dependency_overrides.clear()
+    assert response.status_code == 409
+    assert "version conflict" in response.json()["errors"][0]["message"].lower()
 
 
 def test_admin_observability_failures_returns_envelope() -> None:


### PR DESCRIPTION
## Summary
Restore the narrow editable `app_settings` slice that was missing from `develop` after the stacked PR correction.

## What Changed
- reintroduce the backend allowlisted app setting mutation path for the original three runtime-backed keys
- add the operator console PATCH route for admin app setting updates
- restore frontend API client and System Health inline edit controls for the same narrow slice
- restore focused backend, API, and frontend coverage for allowlisted updates, validation failures, and version conflicts

## Why
`develop` still had the read-only app settings inspection surface, but the editable allowlist path had been removed when the earlier stacked merge was corrected. This puts the original narrow editable slice back in place before we extend it further.

## Impact
- restores the intended narrow admin edit flow without broadening into a generic settings editor
- preserves typed validation, optimistic concurrency, and history/audit behavior through the existing app settings service layer
- keeps non-allowlisted settings inspection-only

## Validation
- `./.venv/bin/python -m pytest media_manager/tests/test_service_layer_admin_benchmarks.py operator_console/tests/test_main.py`
- `npm test -- --run src/test/admin-page.test.tsx src/test/api-client.test.ts src/test/api-endpoints.test.ts`
