### PR TITLE
Issue #46: add pytest markers and slow-test visibility foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,19 @@ Run tests:
 
 Tests expect `TEST_DATABASE_URL` to point at a PostgreSQL database prepared for local test runs.
 
+Useful pytest entry points:
+
+```bash
+./.venv/bin/python -m pytest -q
+./.venv/bin/python -m pytest -q -m unit
+./.venv/bin/python -m pytest -q -m integration
+./.venv/bin/python -m pytest -q --durations=20 --durations-min=1.0
+```
+
+In this repo, `integration` marks tests that require DB-backed fixtures, persist or
+query real DB state, or otherwise depend on real persistence semantics.
+Slow-test visibility is explicit and opt-in; the default required suite remains unchanged.
+
 Build the docs:
 
 ```bash

--- a/media_manager/tests/test_app_settings_stale_flags.py
+++ b/media_manager/tests/test_app_settings_stale_flags.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
 
 def test_media_manager_ui_v2_enabled_has_no_runtime_python_references() -> None:
     runtime_root = Path(__file__).resolve().parent.parent / "app"

--- a/media_manager/tests/test_perf_tooling.py
+++ b/media_manager/tests/test_perf_tooling.py
@@ -5,8 +5,10 @@ from media_manager.app.core.metadata_extractor import MetadataItem, upsert_metad
 import media_manager.app.core.perf as perf_module
 from media_manager.app.core.perf import measure_block, profile_performance
 from media_manager.app.persistence.models import FileContent
+import pytest
 
 
+@pytest.mark.unit
 def test_profile_performance_emits_metric(monkeypatch) -> None:
     calls: list[str] = []
 
@@ -23,6 +25,7 @@ def test_profile_performance_emits_metric(monkeypatch) -> None:
     assert "Perf metric" in calls
 
 
+@pytest.mark.unit
 def test_measure_block_emits_metric(monkeypatch) -> None:
     calls: list[str] = []
 
@@ -35,6 +38,7 @@ def test_measure_block_emits_metric(monkeypatch) -> None:
     assert "Perf metric" in calls
 
 
+@pytest.mark.unit
 def test_metadata_cache_stats_are_deterministic() -> None:
     cache = MetadataCache()
     assert cache.stats().hit_rate == 0.0
@@ -51,6 +55,7 @@ def test_metadata_cache_stats_are_deterministic() -> None:
     assert 0.0 < stats.hit_rate <= 1.0
 
 
+@pytest.mark.integration
 def test_upsert_metadata_bulk_includes_batch_metrics(session_factory) -> None:
     with session_factory() as session:
         c1 = FileContent(sha256_hash="h1")

--- a/media_manager/tests/test_service_layer_operations.py
+++ b/media_manager/tests/test_service_layer_operations.py
@@ -14,6 +14,9 @@ from media_manager.app.persistence.ingest import IngestSummary
 from media_manager.app.persistence.planner import PlanningSummary
 from media_manager.app.service_layer.operations import OperationServices
 
+# This module intentionally uses fakes and a non-DB session_factory sentinel.
+pytestmark = pytest.mark.unit
+
 
 @dataclass
 class _FakeCache:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ include = ["media_manager*", "operator_console*"]
 
 [tool.pytest.ini_options]
 testpaths = ["media_manager/tests", "operator_console/tests"]
+addopts = "--strict-markers"
+markers = [
+  "unit: pure tests with no DB dependency",
+  "integration: tests that require DB-backed fixtures, persist or query real DB state, or depend on real persistence semantics",
+]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary
- add strict pytest marker registration for `unit` and `integration`
- classify the initial clearly justified test set
- document explicit slow-test visibility commands without changing default suite behavior

## Validation
- targeted changed-file pytest runs passed
- marker-selection validation passed
- marker registry validation passed
- full local Python suite passed: `620 passed, 42 warnings in 488.50s (0:08:08)`

## Notes
- no DB isolation semantics changed
- no cleanup narrowing, rollback isolation, xdist, or fixture redesign in this PR
- an initial parallel validation attempt hit shared test DB deadlocks, reinforcing that shared-db parallel pytest is unsafe in the current harness

## Issue tracking
- related to #46
- follow-up child issues will track the next steps for durations-driven hotspot classification and per-worker isolated DB design
