### PR TITLE
Issue #53: expand safe unit classification from measured pytest hotspots

### DIFF
--- a/media_manager/tests/test_canonical_policies.py
+++ b/media_manager/tests/test_canonical_policies.py
@@ -17,6 +17,9 @@ from media_manager.app.core.errors import CanonicalPolicyException
 from media_manager.app.persistence.models import FileInstance, FileInstanceStatus
 
 
+pytestmark = pytest.mark.unit
+
+
 def _instance(path: str, *, seen_second: int) -> FileInstance:
     return FileInstance(
         file_instance_id=uuid.uuid4(),
@@ -140,4 +143,3 @@ def test_policies_raise_for_empty_candidate_list() -> None:
         ShortestPathPolicy().select("x", [], context)
     with pytest.raises(CanonicalPolicyException):
         ExifFilenameFallbackPolicy().select("x", [], context)
-

--- a/media_manager/tests/test_duplicate_integrity_recommendations.py
+++ b/media_manager/tests/test_duplicate_integrity_recommendations.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import pytest
+
 from media_manager.app.persistence.duplicate_integrity_recommendations import (
     DuplicateRecommendationFacts,
     derive_duplicate_recommendation,
 )
+
+
+pytestmark = pytest.mark.unit
 
 
 def _facts(**overrides: object) -> DuplicateRecommendationFacts:

--- a/media_manager/tests/test_env_sample_sync.py
+++ b/media_manager/tests/test_env_sample_sync.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 RE_GETENV = re.compile(r"""os\.getenv\(\s*["']([A-Z][A-Z0-9_]*)["']""")
 RE_ENVIRON = re.compile(r"""os\.environ\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\]""")
 RE_FLAG_ENABLED = re.compile(r"""_flag_enabled\(\s*["']([A-Z][A-Z0-9_]*)["']\s*\)""")
@@ -15,6 +17,9 @@ RE_APP_SETTING_ENV_VAR = re.compile(r"""env_var\s*=\s*["']([A-Z][A-Z0-9_]*)["']"
 RE_ENV_LINE = re.compile(r"""^([A-Z][A-Z0-9_]*)\s*=""")
 
 SCAN_DIRS = ("media_manager", "migrations", "operator_console", "tools")
+
+
+pytestmark = pytest.mark.unit
 
 
 def _repo_root() -> Path:

--- a/media_manager/tests/test_gitignore_artifacts.py
+++ b/media_manager/tests/test_gitignore_artifacts.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
 
 def test_artifacts_path_is_gitignored() -> None:
     repo_root = Path(__file__).resolve().parents[2]

--- a/media_manager/tests/test_persistence_base.py
+++ b/media_manager/tests/test_persistence_base.py
@@ -5,6 +5,9 @@ import pytest
 from media_manager.app.persistence.base import get_database_url
 
 
+pytestmark = pytest.mark.unit
+
+
 def test_get_database_url_accepts_valid_postgres_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(
         "DATABASE_URL",

--- a/media_manager/tests/test_planning_core.py
+++ b/media_manager/tests/test_planning_core.py
@@ -17,6 +17,9 @@ from media_manager.app.core.path_resolver import (
 )
 
 
+pytestmark = pytest.mark.unit
+
+
 def test_date_extraction_priority_metadata_over_filename_and_fs(tmp_path: Path) -> None:
     p = tmp_path / "IMG_20200101_010101.jpg"
     p.write_bytes(b"abc")

--- a/media_manager/tests/test_service_layer_cache.py
+++ b/media_manager/tests/test_service_layer_cache.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import time
 
+import pytest
+
 from media_manager.app.service_layer.cache import ServiceCache
+
+
+pytestmark = pytest.mark.unit
 
 
 def test_service_cache_set_get_and_invalidate() -> None:

--- a/media_manager/tests/test_tag_normalization.py
+++ b/media_manager/tests/test_tag_normalization.py
@@ -5,6 +5,9 @@ import pytest
 from media_manager.app.persistence.tag_normalization import normalize_tag_list, normalize_tag_name
 
 
+pytestmark = pytest.mark.unit
+
+
 def test_normalize_tag_name_trims_lowercases_and_collapses_spaces() -> None:
     assert normalize_tag_name("  SUMMER    Trip  ") == "summer trip"
 


### PR DESCRIPTION
## Summary
- use explicit `pytest --durations` output to identify real hotspot patterns
- expand `unit` classification only for clearly verified pure test files
- keep default pytest behavior and DB isolation semantics unchanged

## Validation
- explicit durations profiling run completed: `620 passed, 42 warnings in 515.54s (0:08:35)`
- targeted changed-file pytest runs passed: `49 passed in 111.28s (0:01:51)`
- `-m unit` validation for changed files passed: `49 passed in 112.42s (0:01:52)`
- full local Python suite passed: `620 passed, 42 warnings in 630.41s (0:10:30)`

## Notes
- hotspot evidence remains dominated by DB-backed integration/setup cost rather than pure helper logic
- even logically pure files still run under the repo-wide autouse DB-backed harness; this PR does not change that execution model
- no changes to `conftest.py`, cleanup scope, rollback isolation, xdist, per-worker DBs, or fixture behavior

## Issue tracking
- related to #53
- parent umbrella remains #46
- safe per-worker DB isolation design remains tracked separately in #54
