### PR TITLE
chore: add backend test workflow and codecov setup

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
     env:
       TEST_DATABASE_URL: postgresql+psycopg://mm_user:mm_pass@localhost:5432/media_manager_test
-
+      DATABASE_URL: postgresql+psycopg://mm_user:mm_pass@localhost:5432/media_manager_test
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -15,6 +15,24 @@ jobs:
     name: Run backend tests and upload coverage
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: mm_user
+          POSTGRES_PASSWORD: mm_pass
+          POSTGRES_DB: media_manager_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U mm_user -d media_manager_test"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      TEST_DATABASE_URL: postgresql+psycopg://mm_user:mm_pass@localhost:5432/media_manager_test
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,46 @@
+name: Backend Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: backend-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-backend:
+    name: Run backend tests and upload coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run backend tests with coverage
+        run: |
+          pytest \
+            --cov=media_manager \
+            --cov-report=xml \
+            --cov-report=term-missing
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0,<9.0",
+  "pytest-cov>=5.0,<6.0",
   "ruff>=0.5,<0.8",
   "psutil>=5.9,<6.0",
   "httpx>=0.27,<1.0",


### PR DESCRIPTION
## Summary

* add `pytest-cov` to the Python dev dependencies
* add a backend GitHub Actions workflow that runs the backend test suite and uploads coverage to Codecov
* add a minimal `codecov.yml` for project and patch coverage reporting

## Why

The repo already had a docs workflow, but it did not have a proper backend test workflow with coverage wired into the normal CI path. This change adds that baseline CI/coverage plumbing in a cleaner shape than the earlier standalone coverage-only attempt.

## Validation

Local validation completed with coverage collection enabled:

* `python -m pip install -e ".[dev]"`
* `pytest --cov=media_manager --cov-report=xml --cov-report=term-missing`

Result:

* `616 passed`
* `4 failed`
* `42 warnings`
* `coverage.xml` generated successfully
* total coverage reported: `86%`

## Notes

The 4 failing tests are pre-existing failures concentrated in `media_manager/tests/test_phase3_duplicate_reclaim.py` and are not introduced by this PR. This change is limited to CI/coverage setup and does not attempt to fix duplicate reclaim restore behavior.

## Files changed

* `pyproject.toml`
* `.github/workflows/backend-tests.yml`
* `codecov.yml`
