### PR TITLE
feat(gui): remove header CTAs and standardize page controls on operations and duplicates

### DIFF
--- a/operator_console/gui_app/src/pages/DuplicatesPage.tsx
+++ b/operator_console/gui_app/src/pages/DuplicatesPage.tsx
@@ -1482,15 +1482,17 @@ export default function DuplicatesPage() {
           : "max-w-[120rem] gap-4 px-3 py-4 sm:px-4 lg:px-5",
       )}
     >
-      <TopSurfaceHeader
-        badge="Duplicate Review"
-        title="Work duplicate decisions in focused steps."
-        description="Compare duplicates, move extra copies to the Recycle Bin, restore them if needed, and keep playback review separate."
-        icon={Copy}
-        density={activeTab === "review" ? "compact" : "default"}
-        className={activeTab === "review" ? "rounded-[24px]" : undefined}
-        contentClassName={activeTab === "review" ? "px-4 py-3 sm:px-4 lg:px-5 lg:py-4" : undefined}
-      />
+      <div data-page-header data-testid="duplicates-page-header">
+        <TopSurfaceHeader
+          badge="Duplicate Review"
+          title="Work duplicate decisions in focused steps."
+          description="Compare duplicates, move extra copies to the Recycle Bin, restore them if needed, and keep playback review separate."
+          icon={Copy}
+          density={activeTab === "review" ? "compact" : "default"}
+          className={activeTab === "review" ? "rounded-[24px]" : undefined}
+          contentClassName={activeTab === "review" ? "px-4 py-3 sm:px-4 lg:px-5 lg:py-4" : undefined}
+        />
+      </div>
 
       {duplicatesQuery.error && (
         <ErrorAlert message={getErrorMessage(duplicatesQuery.error) || "Failed to load duplicate groups"} />
@@ -1525,15 +1527,21 @@ export default function DuplicatesPage() {
         />
       ) : (
         <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as DuplicatesTab)} className="space-y-4">
+          <section
+            data-page-controls
+            data-testid="duplicates-page-controls"
+            className="rounded-[24px] border border-border/70 bg-card/95 p-1 shadow-sm"
+          >
+            <TabsList className="flex h-auto w-full flex-wrap justify-start gap-2 rounded-[18px] bg-muted/60 p-1">
+              <TabsTrigger value="review">Review duplicates</TabsTrigger>
+              <TabsTrigger value="ready-for-bin">Ready for Bin</TabsTrigger>
+              <TabsTrigger value="recycle-bin">Recycle Bin</TabsTrigger>
+              <TabsTrigger value="playback-issues">Playback issues</TabsTrigger>
+            </TabsList>
+          </section>
+
           <Card className={cn("rounded-[24px] border-border/70 bg-card/95 shadow-sm", activeTab === "review" && "shadow-none")}>
             <CardContent className={cn("space-y-4 p-4", activeTab === "review" && "space-y-3 p-2.5 sm:p-3")}>
-              <TabsList className="flex h-auto w-full flex-wrap justify-start gap-2 rounded-[18px] bg-muted/60 p-1">
-                <TabsTrigger value="review">Review duplicates</TabsTrigger>
-                <TabsTrigger value="ready-for-bin">Ready for Bin</TabsTrigger>
-                <TabsTrigger value="recycle-bin">Recycle Bin</TabsTrigger>
-                <TabsTrigger value="playback-issues">Playback issues</TabsTrigger>
-              </TabsList>
-
               <TabsContent value="review" className="mt-0">
                 <div className="space-y-2">
                   <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">

--- a/operator_console/gui_app/src/pages/OperationsPage.tsx
+++ b/operator_console/gui_app/src/pages/OperationsPage.tsx
@@ -697,24 +697,26 @@ export default function OperationsPage() {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 p-6">
-      <TopSurfaceHeader
-        badge="Import"
-        title="Continue the pipeline with more room to think and review."
-        description="Each action below opens into its own full-width workspace so you can review guidance, inputs, and results without squeezing the important parts into side-by-side cards."
-        icon={Sparkles}
-      >
-        <div className="flex flex-wrap gap-3">
-          <Button asChild size="sm">
-            <Link to="/pipeline-wizard">
-              Open Organize
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
-          </Button>
-          <Button asChild variant="outline" size="sm">
-            <Link to="/admin?tab=activity">Review Activity</Link>
-          </Button>
-        </div>
-      </TopSurfaceHeader>
+      <div data-page-header data-testid="operations-page-header">
+        <TopSurfaceHeader
+          badge="Import"
+          title="Continue the pipeline with more room to think and review."
+          description="Each action below opens into its own full-width workspace so you can review guidance, inputs, and results without squeezing the important parts into side-by-side cards."
+          icon={Sparkles}
+        />
+      </div>
+
+      <section data-page-controls data-testid="operations-page-controls" className="flex flex-wrap gap-3">
+        <Button asChild size="sm">
+          <Link to="/pipeline-wizard">
+            Open Organize
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/admin?tab=activity">Review Activity</Link>
+        </Button>
+      </section>
 
       {/* Keep one shared live panel above the action sections so progress stays visible while users move between explicit operation controls. */}
       <LiveProgressPanel

--- a/operator_console/gui_app/src/test/duplicates-page.test.tsx
+++ b/operator_console/gui_app/src/test/duplicates-page.test.tsx
@@ -293,6 +293,15 @@ describe("DuplicatesPage", () => {
   it("defaults to the review tab with comparison content dominant and no Recycle Bin actions", async () => {
     renderPage();
 
+    const pageControls = await screen.findByTestId("duplicates-page-controls");
+    const pageHeader = screen.getByTestId("duplicates-page-header");
+    expect(pageHeader.querySelector("button")).toBeNull();
+
+    expect(within(pageControls).getByRole("tab", { name: "Review duplicates" })).toBeInTheDocument();
+    expect(within(pageControls).getByRole("tab", { name: "Ready for Bin" })).toBeInTheDocument();
+    expect(within(pageControls).getByRole("tab", { name: "Recycle Bin" })).toBeInTheDocument();
+    expect(within(pageControls).getByRole("tab", { name: "Playback issues" })).toBeInTheDocument();
+
     expect(await screen.findByRole("heading", { name: "Review duplicates" })).toBeInTheDocument();
     expect(screen.getByTestId("review-group-navigation-hidden")).toBeInTheDocument();
     expect(screen.getAllByText("alpha-main.jpg").length).toBeGreaterThan(0);

--- a/operator_console/gui_app/src/test/duplicates-page.test.tsx
+++ b/operator_console/gui_app/src/test/duplicates-page.test.tsx
@@ -295,7 +295,8 @@ describe("DuplicatesPage", () => {
 
     const pageControls = await screen.findByTestId("duplicates-page-controls");
     const pageHeader = screen.getByTestId("duplicates-page-header");
-    expect(pageHeader.querySelector("button")).toBeNull();
+    expect(within(pageHeader).queryByRole("button")).toBeNull();
+    expect(within(pageHeader).queryByRole("link")).toBeNull();
 
     expect(within(pageControls).getByRole("tab", { name: "Review duplicates" })).toBeInTheDocument();
     expect(within(pageControls).getByRole("tab", { name: "Ready for Bin" })).toBeInTheDocument();

--- a/operator_console/gui_app/src/test/library-actions-page.test.tsx
+++ b/operator_console/gui_app/src/test/library-actions-page.test.tsx
@@ -223,7 +223,8 @@ describe("Import page", () => {
     expect(screen.queryByText("Mutating")).not.toBeInTheDocument();
     const pageControls = screen.getByTestId("operations-page-controls");
     const pageHeader = screen.getByTestId("operations-page-header");
-    expect(pageHeader.querySelector("a")).toBeNull();
+    expect(within(pageHeader).queryByRole("link")).toBeNull();
+    expect(within(pageHeader).queryByRole("button")).toBeNull();
 
     expect(within(pageControls).getByRole("link", { name: "Open Organize" })).toBeInTheDocument();
     expect(within(pageControls).getByRole("link", { name: "Review Activity" })).toBeInTheDocument();

--- a/operator_console/gui_app/src/test/library-actions-page.test.tsx
+++ b/operator_console/gui_app/src/test/library-actions-page.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -221,7 +221,12 @@ describe("Import page", () => {
     expect(screen.getByText("Add Searchable Details")).toBeInTheDocument();
     expect(screen.queryByText("Legacy Composite Run")).not.toBeInTheDocument();
     expect(screen.queryByText("Mutating")).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Open Organize" })).toBeInTheDocument();
+    const pageControls = screen.getByTestId("operations-page-controls");
+    const pageHeader = screen.getByTestId("operations-page-header");
+    expect(pageHeader.querySelector("a")).toBeNull();
+
+    expect(within(pageControls).getByRole("link", { name: "Open Organize" })).toBeInTheDocument();
+    expect(within(pageControls).getByRole("link", { name: "Review Activity" })).toBeInTheDocument();
     expect(await screen.findByText("[ WAITING FOR LOGS ]")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Implements Issue #9 as a narrow local-composition slice to standardize page-level action placement.

This change enforces the rule that page headers orient rather than act as CTA hubs, and introduces explicit page controls zones on the two proof pages:
- Operations
- Duplicates

## What changed

### Operations page
- moved `Open Organize` and `Review Activity` out of `TopSurfaceHeader`
- added a dedicated page controls zone directly below the header
- added stable markers:
  - `data-page-controls`
  - `data-testid="operations-page-controls"`
  - `data-page-header`
  - `data-testid="operations-page-header"`

### Duplicates page
- kept the header orientation-only
- promoted the existing tab switcher into its own page controls section within the existing `Tabs` context
- added stable markers:
  - `data-page-controls`
  - `data-testid="duplicates-page-controls"`
  - `data-page-header`
  - `data-testid="duplicates-page-header"`
- left downstream review/workflow surfaces unchanged

## Scope guard

This PR intentionally does **not**:
- modify `TopSurfaceHeader`
- reopen shell work from #8
- absorb spacing/rhythm cleanup from #10
- redesign workflow surfaces
- perform unrelated GUI cleanup

## Tests

Updated:
- `src/test/library-actions-page.test.tsx`
- `src/test/duplicates-page.test.tsx`

Validation run:
- `npm test -- src/test/library-actions-page.test.tsx src/test/duplicates-page.test.tsx`

Result:
- `56/56` tests passed

## Why this slice

Issue #9 is being treated as an **action placement contract**:
- headers orient, not control
- page-level actions belong in a dedicated page controls zone
- workflow actions stay near the active work surface

This PR proves that contract on the two agreed proof pages without widening into a broader redesign.

Closes #9