### PR TITLE
feat(gui): normalize proof-page spacing rhythm and fix gallery test settling

### DIFF
--- a/operator_console/gui_app/src/components/wizard/WizardProgressHeader.tsx
+++ b/operator_console/gui_app/src/components/wizard/WizardProgressHeader.tsx
@@ -96,9 +96,9 @@ export function WizardProgressHeader({
 }: WizardProgressHeaderProps) {
   return (
     <Card className="rounded-2xl border-border/80 bg-card/80 shadow-sm">
-      <CardContent className="space-y-3 p-4">
+      <CardContent className="space-y-2.5 p-4">
         <div className="flex items-center justify-between gap-4">
-          <div className="min-w-0 flex-1 space-y-2">
+          <div className="min-w-0 flex-1 space-y-1.5">
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Progress</p>
             <div className="flex items-center gap-2">
               {items.map((item, index) => (
@@ -112,7 +112,7 @@ export function WizardProgressHeader({
           {secondaryAction}
         </div>
 
-        <div className="space-y-1">
+        <div className="space-y-0.5">
           <p className="text-sm text-muted-foreground">
             Step {currentIndex + 1} of {totalSteps}
           </p>

--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -77,7 +77,7 @@ export default function GalleryPage() {
   const [tagInput, setTagInput] = useState("");
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const tagsParam = searchParams.get("tags") || "";
-  const selectedTags = tagsParam.split(",").filter(Boolean);
+  const selectedTags = useMemo(() => tagsParam.split(",").filter(Boolean), [tagsParam]);
   const sortBy = searchParams.get("sort_by") || "created_at";
   const sortOrder = searchParams.get("sort_order") || "desc";
   const page = Math.max(1, Number(searchParams.get("page") || 1));
@@ -131,7 +131,7 @@ export default function GalleryPage() {
 
   const data = (galleryQuery.data as PaginatedResponse<CanonicalFile> | undefined) ?? null;
   const items = data?.items ?? [];
-  const allTags = (tagsQuery.data as Tag[] | undefined) ?? [];
+  const allTags = useMemo(() => (tagsQuery.data as Tag[] | undefined) ?? [], [tagsQuery.data]);
   const totalCount = data?.total_count ?? 0;
   const totalPages = Math.max(data?.total_pages ?? 1, 1);
   const visiblePages = useMemo(() => getVisiblePages(page, totalPages), [page, totalPages]);
@@ -155,7 +155,7 @@ export default function GalleryPage() {
 
   const controls = (
     <div className="rounded-[28px] border border-border/70 bg-card/70 p-4 shadow-sm backdrop-blur">
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
         <div className="flex flex-wrap gap-3">
           <div className="rounded-2xl border border-border/70 bg-background/85 px-4 py-3 text-sm text-muted-foreground shadow-sm">
             {selectedTags.length
@@ -212,6 +212,7 @@ export default function GalleryPage() {
                     key={tag}
                     type="button"
                     onClick={() => removeTag(tag)}
+                    aria-label={`Remove tag filter ${tag}`}
                     className="inline-flex items-center gap-1 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-medium text-primary"
                   >
                     {tag}
@@ -294,71 +295,73 @@ export default function GalleryPage() {
         />
       ) : null}
 
-      <MediaGrid
-        files={items}
-        loading={galleryQuery.isLoading && !data}
-        gridClassName={densityPreset.gridClassName}
-        skeletonCount={densityPreset.limit}
-        density={densityPreset.key}
-        emptyTitle="No media files"
-        emptyDescription={
-          selectedTags.length
-            ? "Try adjusting your tag filters or sort order."
-            : "Run an ingest to populate the gallery."
-        }
-        onPreview={setSelectedFile}
-        getDetailHref={(file) => `/gallery/${file.id}`}
-      />
+      <div data-page-primary-surface className="-mt-1 space-y-5">
+        <MediaGrid
+          files={items}
+          loading={galleryQuery.isLoading && !data}
+          gridClassName={densityPreset.gridClassName}
+          skeletonCount={densityPreset.limit}
+          density={densityPreset.key}
+          emptyTitle="No media files"
+          emptyDescription={
+            selectedTags.length
+              ? "Try adjusting your tag filters or sort order."
+              : "Run an ingest to populate the gallery."
+          }
+          onPreview={setSelectedFile}
+          getDetailHref={(file) => `/gallery/${file.id}`}
+        />
 
-      {data && totalPages > 1 && (
-        <Pagination className="justify-center">
-          <PaginationContent>
-            <PaginationItem>
-              <PaginationPrevious
-                href="#"
-                onClick={(event) => {
-                  event.preventDefault();
-                  if (page === 1) return;
-                  updateParams({ page: page - 1 <= 1 ? undefined : String(page - 1) });
-                }}
-                className={page === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"}
-              />
-            </PaginationItem>
-            {visiblePages.map((pageNumber, index) =>
-              pageNumber === "ellipsis" ? (
-                <PaginationItem key={`ellipsis-${index}`}>
-                  <PaginationEllipsis />
-                </PaginationItem>
-              ) : (
-                <PaginationItem key={pageNumber}>
-                  <PaginationLink
-                    href="#"
-                    isActive={pageNumber === page}
-                    onClick={(event) => {
-                      event.preventDefault();
-                      updateParams({ page: pageNumber === 1 ? undefined : String(pageNumber) });
-                    }}
-                    className="cursor-pointer"
-                  >
-                    {pageNumber}
-                  </PaginationLink>
-                </PaginationItem>
-              ),
-            )}
-            <PaginationItem>
-              <PaginationNext
-                href="#"
-                onClick={(event) => {
-                  event.preventDefault();
-                  if (page >= totalPages) return;
-                  updateParams({ page: String(page + 1) });
-                }}
-                className={page >= totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
-              />
-            </PaginationItem>
-          </PaginationContent>
-        </Pagination>
-      )}
+        {data && totalPages > 1 && (
+          <Pagination className="justify-center">
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  href="#"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    if (page === 1) return;
+                    updateParams({ page: page - 1 <= 1 ? undefined : String(page - 1) });
+                  }}
+                  className={page === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                />
+              </PaginationItem>
+              {visiblePages.map((pageNumber, index) =>
+                pageNumber === "ellipsis" ? (
+                  <PaginationItem key={`ellipsis-${index}`}>
+                    <PaginationEllipsis />
+                  </PaginationItem>
+                ) : (
+                  <PaginationItem key={pageNumber}>
+                    <PaginationLink
+                      href="#"
+                      isActive={pageNumber === page}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        updateParams({ page: pageNumber === 1 ? undefined : String(pageNumber) });
+                      }}
+                      className="cursor-pointer"
+                    >
+                      {pageNumber}
+                    </PaginationLink>
+                  </PaginationItem>
+                ),
+              )}
+              <PaginationItem>
+                <PaginationNext
+                  href="#"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    if (page >= totalPages) return;
+                    updateParams({ page: String(page + 1) });
+                  }}
+                  className={page >= totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        )}
+      </div>
 
       <MediaPreviewModal file={selectedFile} onClose={() => setSelectedFile(null)} />
     </PageShell>

--- a/operator_console/gui_app/src/pages/PipelineWizard.tsx
+++ b/operator_console/gui_app/src/pages/PipelineWizard.tsx
@@ -2340,7 +2340,9 @@ export default function PipelineWizard() {
           />
         }
       >
-        {renderCurrentStep()}
+        <div data-page-primary-surface className="-mt-1">
+          {renderCurrentStep()}
+        </div>
       </PageShell>
 
       <ConfirmDialog

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -80,9 +80,10 @@ describe("Gallery page", () => {
     ).toBeInTheDocument();
     expect(document.querySelector('[data-page-shell="browse-list"]')).toBeTruthy();
     expect(document.querySelector("[data-page-shell-controls]")).toBeTruthy();
+    expect(document.querySelector("[data-page-primary-surface]")).toBeTruthy();
     expect(screen.getByPlaceholderText("Filter gallery by tag")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Descending" })).toBeInTheDocument();
-    expect(screen.getByText("1 item · Page 1 of 1")).toBeInTheDocument();
+    expect(await screen.findByText("1 item · Page 1 of 1")).toBeInTheDocument();
   });
 
   it("keeps filter controls interactive inside the shell controls row", async () => {
@@ -92,9 +93,7 @@ describe("Gallery page", () => {
     fireEvent.change(input, { target: { value: "travel" } });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /travel/i })).toBeInTheDocument();
-    });
+    expect(await screen.findByRole("button", { name: "Remove tag filter travel" })).toBeInTheDocument();
     expect(mocks.getCanonical).toHaveBeenLastCalledWith(
       expect.objectContaining({
         page: 1,

--- a/operator_console/gui_app/src/test/pipeline-wizard-page.test.tsx
+++ b/operator_console/gui_app/src/test/pipeline-wizard-page.test.tsx
@@ -105,6 +105,7 @@ describe("Pipeline Wizard page", () => {
     ).toBeInTheDocument();
     expect(document.querySelector('[data-page-shell="workflow"]')).toBeTruthy();
     expect(document.querySelector("[data-page-shell-controls]")).toBeTruthy();
+    expect(document.querySelector("[data-page-primary-surface]")).toBeTruthy();
     expect(screen.getAllByText("Progress").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Abort Wizard" })).toBeInTheDocument();
     expect(await screen.findByText("[ INGEST READY ]")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Implements the Issue #10 proof-page slice for spacing/rhythm normalization on:
- `GalleryPage`
- `PipelineWizard`

This keeps the work tightly bounded to proof-page top-band rhythm and primary work-surface alignment. It does not reopen shell choice, CTA placement, workflow design, or broad component restyling.

## What changed

- tightened top-band spacing on the two in-scope proof pages
- moved the first primary work surface slightly higher beneath the existing title/controls framing
- tightened `WizardProgressHeader` internal vertical rhythm because it directly contributed to stacked-band drag on the in-scope workflow proof page
- added `data-page-primary-surface` markers so the first work surface is structurally testable
- preserved the #8/#9 shell markers and page-level action placement contracts

## Follow-up fix included

While validating the proof pages, `gallery-page.test.tsx` was hanging instead of failing normally.

Root cause:
- `GalleryPage` had a render loop in the tag-suggestions effect
- dependencies included arrays recreated on every render
- the empty-input branch repeatedly set `suggestions` to a fresh empty array
- this prevented the test from settling

Fix:
- memoized the relevant tag arrays
- added an explicit accessible label for the removable tag chip
- updated the Gallery test to wait for async query resolution and use the deterministic accessible name

## Out of scope / not changed

- no shell redesign
- no CTA relocation
- no workflow rewrite
- no whole-app spacing pass
- no broad header or card refactor

## Verification

- `src/test/pipeline-wizard-page.test.tsx` passed
- `src/test/gallery-page.test.tsx` passed