### PR TITLE
fix: stabilize purge lifecycle semantics and read safety

### DIFF
--- a/media_manager/app/persistence/operator_console.py
+++ b/media_manager/app/persistence/operator_console.py
@@ -1530,7 +1530,7 @@ class OperatorConsoleReadService:
                     source_path=(
                         (item.recycle_path or item.quarantine_path)
                         if item.quarantine_status == "RECYCLED" and item.purged_at is None
-                        else (item.quarantine_path if item.quarantine_status == "RECYCLED" else item.original_path)
+                        else item.original_path
                     ),
                     recycle_path=item.recycle_path,
                     current_status=item.quarantine_status,

--- a/media_manager/app/persistence/operator_console.py
+++ b/media_manager/app/persistence/operator_console.py
@@ -1527,7 +1527,11 @@ class OperatorConsoleReadService:
                 RetentionRecycleItem(
                     workflow="integrity_quarantine",
                     file_instance_id=str(item.file_instance_id),
-                    source_path=item.quarantine_path if item.quarantine_status == "RECYCLED" else item.original_path,
+                    source_path=(
+                        (item.recycle_path or item.quarantine_path)
+                        if item.quarantine_status == "RECYCLED" and item.purged_at is None
+                        else (item.quarantine_path if item.quarantine_status == "RECYCLED" else item.original_path)
+                    ),
                     recycle_path=item.recycle_path,
                     current_status=item.quarantine_status,
                     retention_expires_at=item.expires_at.isoformat() if item.expires_at is not None else None,

--- a/media_manager/app/persistence/operator_console.py
+++ b/media_manager/app/persistence/operator_console.py
@@ -453,7 +453,7 @@ def _duplicate_item_restore_expires_at(row: DuplicateReclaimItem) -> datetime | 
 def _duplicate_item_current_location(row: DuplicateReclaimItem) -> str | None:
     if row.bin_state == "IN_BIN" and row.bin_path:
         return row.bin_path
-    if row.item_status == "RECYCLED":
+    if row.item_status == "RECYCLED" and row.purged_at is None:
         return row.recycle_path
     return None
 

--- a/media_manager/app/persistence/phase3_actions.py
+++ b/media_manager/app/persistence/phase3_actions.py
@@ -269,6 +269,7 @@ class Phase3ActionService:
                             expires_at=expires_at,
                             restore_expires_at=expires_at,
                             bin_state=DuplicateBinState.PENDING_MOVE.value,
+                            purged_at=None,
                             restored_at=None,
                             created_at=now,
                             updated_at=now,
@@ -284,16 +285,13 @@ class Phase3ActionService:
                     existing.bin_path = None
                     existing.item_status = DuplicateReclaimItemStatus.PENDING.value
                     existing.expires_at = expires_at
+                    existing.reclaimed_at = None
                     existing.bin_entered_at = None
                     existing.restore_expires_at = expires_at
                     existing.bin_state = DuplicateBinState.PENDING_MOVE.value
                     existing.recycle_path = None
                     existing.recycled_at = None
                     existing.purge_after_at = None
-                    # TODO(follow-up): purged_at must be reset here so items
-                    # re-entering the reclaim lifecycle after a prior purge are
-                    # not permanently excluded by the `purged_at IS NULL` guard
-                    # in _plan_duplicate_purge.  See PR #75 review discussion.
                     existing.purged_at = None
                     existing.restored_at = None
                     existing.updated_at = now
@@ -438,6 +436,7 @@ class Phase3ActionService:
                         recycle_path=None,
                         recycled_at=None,
                         purge_after_at=None,
+                        purged_at=None,
                         restored_at=None,
                         created_at=now,
                         updated_at=now,
@@ -447,15 +446,13 @@ class Phase3ActionService:
                 record.original_path = file_instance.absolute_path
                 record.quarantine_path = quarantine_path
                 record.quarantine_status = IntegrityQuarantineStatus.PENDING.value
+                record.quarantined_at = None
                 record.expires_at = expires_at
                 record.recycle_path = None
                 record.recycled_at = None
                 record.purge_after_at = None
-                # TODO(follow-up): purged_at must be reset here so items
-                # re-entering the quarantine lifecycle after a prior purge are
-                # not permanently excluded by the `purged_at IS NULL` guard
-                # in _plan_integrity_purge.  See PR #75 review discussion.
                 record.purged_at = None
+                record.restored_at = None
                 record.updated_at = now
 
             session.add(

--- a/media_manager/tests/test_operator_console_duplicates.py
+++ b/media_manager/tests/test_operator_console_duplicates.py
@@ -18,6 +18,7 @@ from media_manager.app.persistence.models import (
     FileInstanceStatus,
     IntegrityCheck,
     IntegrityCheckRun,
+    IntegrityQuarantineRecord,
 )
 from media_manager.app.persistence.operator_console import OperatorConsoleReadService
 
@@ -771,3 +772,95 @@ def test_duplicate_reclaim_archive_page_does_not_fallback_to_legacy_archive_path
     archive_item = next(item for item in archive_page.items if item.file_instance_id == str(file_instance_id))
     assert archive_item.archive_path == ""
     assert archive_item.expires_at == (base + timedelta(days=2)).isoformat()
+
+
+def test_retention_page_prefers_integrity_recycle_path_and_falls_back_to_quarantine_path(session_factory) -> None:
+    service = OperatorConsoleReadService(session_factory)
+    base = datetime(2026, 3, 4, 12, 0, tzinfo=UTC)
+    content_with_recycle = UUID("99999999-1111-1111-1111-111111111111")
+    content_without_recycle = UUID("99999999-2222-2222-2222-222222222222")
+    file_with_recycle = UUID("99999999-1111-1111-1111-111111111112")
+    file_without_recycle = UUID("99999999-2222-2222-2222-222222222223")
+    check_with_recycle = UUID("99999999-1111-1111-1111-111111111113")
+    check_without_recycle = UUID("99999999-2222-2222-2222-222222222224")
+
+    with session_factory.begin() as session:
+        _add_content(session, content_with_recycle, "hash-integrity-recycle", base)
+        _add_content(session, content_without_recycle, "hash-integrity-fallback", base)
+        session.flush()
+        _add_instance(
+            session,
+            file_instance_id=file_with_recycle,
+            content_id=content_with_recycle,
+            absolute_path="/library/integrity-recycle.jpg",
+            first_seen_at=base,
+        )
+        _add_instance(
+            session,
+            file_instance_id=file_without_recycle,
+            content_id=content_without_recycle,
+            absolute_path="/library/integrity-fallback.jpg",
+            first_seen_at=base + timedelta(seconds=1),
+        )
+        _add_integrity_check(
+            session,
+            check_id=check_with_recycle,
+            file_instance_id=file_with_recycle,
+            status="SUSPECT",
+            at=base,
+            absolute_path="/quarantine/integrity-recycle.jpg",
+        )
+        _add_integrity_check(
+            session,
+            check_id=check_without_recycle,
+            file_instance_id=file_without_recycle,
+            status="SUSPECT",
+            at=base + timedelta(seconds=1),
+            absolute_path="/quarantine/integrity-fallback.jpg",
+        )
+        session.add_all(
+            [
+                IntegrityQuarantineRecord(
+                    file_instance_id=file_with_recycle,
+                    check_id=check_with_recycle,
+                    original_path="/library/integrity-recycle.jpg",
+                    quarantine_path="/quarantine/integrity-recycle.jpg",
+                    quarantine_status="RECYCLED",
+                    quarantined_at=base - timedelta(days=4),
+                    expires_at=base - timedelta(days=2),
+                    recycle_path="/recycle/integrity-recycle.jpg",
+                    recycled_at=base - timedelta(days=1),
+                    purge_after_at=base + timedelta(days=7),
+                    purged_at=None,
+                    restored_at=None,
+                    created_at=base - timedelta(days=4),
+                    updated_at=base,
+                ),
+                IntegrityQuarantineRecord(
+                    file_instance_id=file_without_recycle,
+                    check_id=check_without_recycle,
+                    original_path="/library/integrity-fallback.jpg",
+                    quarantine_path="/quarantine/integrity-fallback.jpg",
+                    quarantine_status="RECYCLED",
+                    quarantined_at=base - timedelta(days=4),
+                    expires_at=base - timedelta(days=2),
+                    recycle_path=None,
+                    recycled_at=base - timedelta(days=1),
+                    purge_after_at=base + timedelta(days=7),
+                    purged_at=None,
+                    restored_at=None,
+                    created_at=base - timedelta(days=4),
+                    updated_at=base,
+                ),
+            ]
+        )
+
+    retention_page = service.get_retention_recycle_page(page=1, limit=20)
+
+    with_recycle_row = next(item for item in retention_page.items if item.file_instance_id == str(file_with_recycle))
+    assert with_recycle_row.workflow == "integrity_quarantine"
+    assert with_recycle_row.source_path == "/recycle/integrity-recycle.jpg"
+
+    without_recycle_row = next(item for item in retention_page.items if item.file_instance_id == str(file_without_recycle))
+    assert without_recycle_row.workflow == "integrity_quarantine"
+    assert without_recycle_row.source_path == "/quarantine/integrity-fallback.jpg"

--- a/media_manager/tests/test_operator_console_duplicates.py
+++ b/media_manager/tests/test_operator_console_duplicates.py
@@ -779,14 +779,18 @@ def test_retention_page_prefers_integrity_recycle_path_and_falls_back_to_quarant
     base = datetime(2026, 3, 4, 12, 0, tzinfo=UTC)
     content_with_recycle = UUID("99999999-1111-1111-1111-111111111111")
     content_without_recycle = UUID("99999999-2222-2222-2222-222222222222")
+    content_purged = UUID("99999999-3333-3333-3333-333333333333")
     file_with_recycle = UUID("99999999-1111-1111-1111-111111111112")
     file_without_recycle = UUID("99999999-2222-2222-2222-222222222223")
+    file_purged = UUID("99999999-3333-3333-3333-333333333334")
     check_with_recycle = UUID("99999999-1111-1111-1111-111111111113")
     check_without_recycle = UUID("99999999-2222-2222-2222-222222222224")
+    check_purged = UUID("99999999-3333-3333-3333-333333333335")
 
     with session_factory.begin() as session:
         _add_content(session, content_with_recycle, "hash-integrity-recycle", base)
         _add_content(session, content_without_recycle, "hash-integrity-fallback", base)
+        _add_content(session, content_purged, "hash-integrity-purged", base)
         session.flush()
         _add_instance(
             session,
@@ -801,6 +805,13 @@ def test_retention_page_prefers_integrity_recycle_path_and_falls_back_to_quarant
             content_id=content_without_recycle,
             absolute_path="/library/integrity-fallback.jpg",
             first_seen_at=base + timedelta(seconds=1),
+        )
+        _add_instance(
+            session,
+            file_instance_id=file_purged,
+            content_id=content_purged,
+            absolute_path="/library/integrity-purged.jpg",
+            first_seen_at=base + timedelta(seconds=2),
         )
         _add_integrity_check(
             session,
@@ -817,6 +828,14 @@ def test_retention_page_prefers_integrity_recycle_path_and_falls_back_to_quarant
             status="SUSPECT",
             at=base + timedelta(seconds=1),
             absolute_path="/quarantine/integrity-fallback.jpg",
+        )
+        _add_integrity_check(
+            session,
+            check_id=check_purged,
+            file_instance_id=file_purged,
+            status="SUSPECT",
+            at=base + timedelta(seconds=2),
+            absolute_path="/quarantine/integrity-purged.jpg",
         )
         session.add_all(
             [
@@ -852,6 +871,22 @@ def test_retention_page_prefers_integrity_recycle_path_and_falls_back_to_quarant
                     created_at=base - timedelta(days=4),
                     updated_at=base,
                 ),
+                IntegrityQuarantineRecord(
+                    file_instance_id=file_purged,
+                    check_id=check_purged,
+                    original_path="/library/integrity-purged.jpg",
+                    quarantine_path="/quarantine/integrity-purged.jpg",
+                    quarantine_status="RECYCLED",
+                    quarantined_at=base - timedelta(days=8),
+                    expires_at=base - timedelta(days=6),
+                    recycle_path="/recycle/integrity-purged.jpg",
+                    recycled_at=base - timedelta(days=5),
+                    purge_after_at=base - timedelta(days=2),
+                    purged_at=base - timedelta(days=1),
+                    restored_at=None,
+                    created_at=base - timedelta(days=8),
+                    updated_at=base - timedelta(days=1),
+                ),
             ]
         )
 
@@ -864,3 +899,7 @@ def test_retention_page_prefers_integrity_recycle_path_and_falls_back_to_quarant
     without_recycle_row = next(item for item in retention_page.items if item.file_instance_id == str(file_without_recycle))
     assert without_recycle_row.workflow == "integrity_quarantine"
     assert without_recycle_row.source_path == "/quarantine/integrity-fallback.jpg"
+
+    purged_row = next(item for item in retention_page.items if item.file_instance_id == str(file_purged))
+    assert purged_row.workflow == "integrity_quarantine"
+    assert purged_row.source_path == "/library/integrity-purged.jpg"

--- a/media_manager/tests/test_operator_console_duplicates.py
+++ b/media_manager/tests/test_operator_console_duplicates.py
@@ -612,12 +612,15 @@ def test_duplicate_reclaim_operator_pages_use_bin_native_authority(session_facto
     base = datetime(2026, 3, 3, 12, 0, tzinfo=UTC)
     archived_content = UUID("eeeeeeee-1111-1111-1111-111111111111")
     recycled_content = UUID("eeeeeeee-2222-2222-2222-222222222222")
+    purged_content = UUID("eeeeeeee-4444-4444-4444-444444444444")
     archived_file = UUID("eeeeeeee-1111-1111-1111-111111111112")
     recycled_file = UUID("eeeeeeee-2222-2222-2222-222222222223")
+    purged_file = UUID("eeeeeeee-4444-4444-4444-444444444445")
 
     with session_factory.begin() as session:
         _add_content(session, archived_content, "hash-archive-page", base)
         _add_content(session, recycled_content, "hash-retention-page", base)
+        _add_content(session, purged_content, "hash-purged-retention-page", base)
         session.flush()
         _add_instance(
             session,
@@ -632,6 +635,13 @@ def test_duplicate_reclaim_operator_pages_use_bin_native_authority(session_facto
             content_id=recycled_content,
             absolute_path="/bin/current-recycled.jpg",
             first_seen_at=base + timedelta(seconds=1),
+        )
+        _add_instance(
+            session,
+            file_instance_id=purged_file,
+            content_id=purged_content,
+            absolute_path="/library/purged.jpg",
+            first_seen_at=base + timedelta(seconds=2),
         )
         session.add_all(
             [
@@ -677,6 +687,27 @@ def test_duplicate_reclaim_operator_pages_use_bin_native_authority(session_facto
                     created_at=base,
                     updated_at=base,
                 ),
+                DuplicateReclaimItem(
+                    file_instance_id=purged_file,
+                    content_id=purged_content,
+                    original_path="/library/purged.jpg",
+                    archive_path="/bin/stale-archive-purged.jpg",
+                    planned_bin_path=None,
+                    bin_path="/bin/stale-purged.jpg",
+                    item_status="RECYCLED",
+                    reclaimed_at=base - timedelta(days=14),
+                    bin_entered_at=base - timedelta(days=14),
+                    expires_at=base - timedelta(days=5),
+                    restore_expires_at=base - timedelta(days=8),
+                    bin_state=DuplicateBinState.PURGED.value,
+                    recycle_path="/bin/deleted-purged.jpg",
+                    recycled_at=base - timedelta(days=10),
+                    purge_after_at=base - timedelta(days=1),
+                    purged_at=base - timedelta(hours=6),
+                    restored_at=None,
+                    created_at=base - timedelta(days=14),
+                    updated_at=base - timedelta(hours=6),
+                ),
             ]
         )
 
@@ -690,6 +721,9 @@ def test_duplicate_reclaim_operator_pages_use_bin_native_authority(session_facto
     retention_item = next(item for item in retention_page.items if item.file_instance_id == str(recycled_file))
     assert retention_item.source_path == "/bin/current-recycled.jpg"
     assert retention_item.retention_expires_at == (base - timedelta(days=1)).isoformat()
+
+    purged_retention_item = next(item for item in retention_page.items if item.file_instance_id == str(purged_file))
+    assert purged_retention_item.source_path == "/library/purged.jpg"
 
 
 def test_duplicate_reclaim_archive_page_does_not_fallback_to_legacy_archive_path_for_archived_rows(session_factory) -> None:

--- a/media_manager/tests/test_purge_state_transition.py
+++ b/media_manager/tests/test_purge_state_transition.py
@@ -4,14 +4,17 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import UUID
 
+import pytest
 from sqlalchemy import select
 
+from media_manager.app.persistence.apply import ApplyService
 from media_manager.app.persistence.models import (
     DuplicateBinState,
     DuplicateReclaimItem,
     DuplicateReclaimItemStatus,
     DuplicateReclaimRecord,
     DuplicateReclaimStatus,
+    FailureEvent,
     FileContent,
     FileInstance,
     FileInstanceStatus,
@@ -20,6 +23,8 @@ from media_manager.app.persistence.models import (
     IntegrityQuarantineRecord,
     IntegrityQuarantineStatus,
     PlannedAction,
+    Run,
+    RunStateDB,
 )
 from media_manager.app.persistence.phase3_actions import Phase3ActionService
 
@@ -223,6 +228,7 @@ def test_purge_duplicate_planner_excludes_already_purged_items(
         )
 
     run_id = service._plan_duplicate_purge(file_instance_ids=None)
+    assert run_id is not None, "expected non-null run_id from _plan_duplicate_purge"
 
     with session_factory() as session:
         actions = session.scalars(
@@ -308,9 +314,567 @@ def test_purge_integrity_planner_excludes_already_purged_items(
         )
 
     run_id = service._plan_integrity_purge(file_instance_ids=None)
+    assert run_id is not None, "expected non-null run_id from _plan_integrity_purge"
 
     with session_factory() as session:
         actions = session.scalars(
             select(PlannedAction).where(PlannedAction.run_id == run_id)
         ).all()
         assert len(actions) == 0, "already-purged integrity item must not be re-planned"
+
+
+def test_purge_duplicate_reclaim_is_idempotent_on_repeat(
+    session_factory,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    reclaim_root = tmp_path / "reclaim-root"
+    recycle_root = tmp_path / "recycle-bin-root"
+    monkeypatch.setenv("MEDIA_MANAGER_RECLAIM_ROOT", str(reclaim_root))
+    monkeypatch.setenv("MEDIA_MANAGER_RECYCLE_BIN_ROOT", str(recycle_root))
+    service = Phase3ActionService(session_factory)
+    base = datetime(2026, 4, 10, 13, 0, tzinfo=UTC)
+    monkeypatch.setattr("media_manager.app.persistence.phase3_actions._utcnow", lambda: base + timedelta(days=8))
+    content_id = UUID("d135b1ed-4dc6-4a0d-88d5-81726006507c")
+    canonical_instance = UUID("d135b1ed-4dc6-4a0d-88d5-817260065071")
+    duplicate_instance = UUID("d135b1ed-4dc6-4a0d-88d5-817260065072")
+
+    recycle_path = recycle_root / "duplicates" / str(content_id) / f"{duplicate_instance}-copy.jpg"
+    recycle_path.parent.mkdir(parents=True, exist_ok=True)
+    recycle_path.write_bytes(b"copy-data")
+
+    with session_factory.begin() as session:
+        _add_content(session, content_id, "hash-purge-repeat-dup", base)
+        session.flush()
+        _add_instance(
+            session,
+            file_instance_id=canonical_instance,
+            content_id=content_id,
+            absolute_path=str(tmp_path / "library" / "main.jpg"),
+            first_seen_at=base,
+        )
+        _add_instance(
+            session,
+            file_instance_id=duplicate_instance,
+            content_id=content_id,
+            absolute_path=str(recycle_path),
+            first_seen_at=base + timedelta(seconds=1),
+        )
+        session.add(
+            DuplicateReclaimRecord(
+                content_id=content_id,
+                reclaim_status=DuplicateReclaimStatus.SCHEDULED_FOR_DELETE.value,
+                reviewed_at=base,
+                reviewed_by="tester",
+                restored_at=None,
+                created_at=base,
+                updated_at=base,
+            )
+        )
+        session.add(
+            DuplicateReclaimItem(
+                file_instance_id=duplicate_instance,
+                content_id=content_id,
+                original_path=str(tmp_path / "library" / "copy.jpg"),
+                archive_path=str(recycle_path),
+                planned_bin_path=None,
+                bin_path=str(recycle_path),
+                item_status=DuplicateReclaimItemStatus.RECYCLED.value,
+                reclaimed_at=base,
+                bin_entered_at=base,
+                expires_at=base + timedelta(days=7),
+                restore_expires_at=base + timedelta(days=7),
+                bin_state=DuplicateBinState.IN_BIN.value,
+                recycle_path=str(recycle_path),
+                recycled_at=base,
+                purge_after_at=base + timedelta(days=7),
+                purged_at=None,
+                restored_at=None,
+                created_at=base,
+                updated_at=base,
+            )
+        )
+
+    first = service.purge_duplicate_reclaim(file_instance_ids=[duplicate_instance])
+    second = service.purge_duplicate_reclaim(file_instance_ids=[duplicate_instance])
+
+    assert first["summary"]["applied_count"] == 1
+    assert second["summary"]["applied_count"] == 0
+    assert not recycle_path.exists()
+    with session_factory() as session:
+        item = session.get(DuplicateReclaimItem, duplicate_instance)
+        assert item is not None
+        assert item.bin_state == DuplicateBinState.PURGED.value
+        assert item.purged_at is not None
+
+
+def test_purge_integrity_quarantine_is_idempotent_on_repeat(
+    session_factory,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    reclaim_root = tmp_path / "reclaim-root"
+    recycle_root = tmp_path / "recycle-bin-root"
+    quarantine_root = tmp_path / "quarantine-root"
+    monkeypatch.setenv("MEDIA_MANAGER_RECLAIM_ROOT", str(reclaim_root))
+    monkeypatch.setenv("MEDIA_MANAGER_RECYCLE_BIN_ROOT", str(recycle_root))
+    monkeypatch.setenv("MEDIA_MANAGER_INTEGRITY_QUARANTINE_ROOT", str(quarantine_root))
+    service = Phase3ActionService(session_factory)
+    base = datetime(2026, 4, 10, 14, 0, tzinfo=UTC)
+    monkeypatch.setattr("media_manager.app.persistence.phase3_actions._utcnow", lambda: base + timedelta(days=15))
+    file_instance_id = UUID("e135b1ed-4dc6-4a0d-88d5-817260065072")
+    content_id = UUID("e135b1ed-4dc6-4a0d-88d5-81726006507c")
+    check_id = UUID("e135b1ed-4dc6-4a0d-88d5-817260065073")
+    check_run_id = UUID("e135b1ed-4dc6-4a0d-88d5-817260065074")
+    recycle_path = recycle_root / "integrity" / f"{file_instance_id}-broken.jpg"
+    recycle_path.parent.mkdir(parents=True, exist_ok=True)
+    recycle_path.write_bytes(b"broken")
+
+    with session_factory.begin() as session:
+        _add_content(session, content_id, "hash-purge-repeat-int", base)
+        session.flush()
+        _add_instance(
+            session,
+            file_instance_id=file_instance_id,
+            content_id=content_id,
+            absolute_path=str(recycle_path),
+            first_seen_at=base,
+        )
+        session.add(
+            IntegrityCheckRun(
+                id=check_run_id,
+                scan_mode="DEEP",
+                status="COMPLETED",
+                paths=[str(tmp_path / "library")],
+                scanned_count=1,
+                issues_found=1,
+            )
+        )
+        session.flush()
+        session.add(
+            IntegrityCheck(
+                id=check_id,
+                file_instance_id=file_instance_id,
+                latest_run_id=check_run_id,
+                status="BROKEN",
+            )
+        )
+        session.flush()
+        session.add(
+            IntegrityQuarantineRecord(
+                file_instance_id=file_instance_id,
+                check_id=check_id,
+                original_path=str(tmp_path / "library" / "broken.jpg"),
+                quarantine_path=str(quarantine_root / f"{file_instance_id}-broken.jpg"),
+                quarantine_status=IntegrityQuarantineStatus.RECYCLED.value,
+                quarantined_at=base,
+                expires_at=base + timedelta(days=7),
+                recycle_path=str(recycle_path),
+                recycled_at=base + timedelta(days=7),
+                purge_after_at=base + timedelta(days=14),
+                purged_at=None,
+                restored_at=None,
+                created_at=base,
+                updated_at=base,
+            )
+        )
+
+    first = service.purge_integrity_quarantine(file_instance_ids=[file_instance_id])
+    second = service.purge_integrity_quarantine(file_instance_ids=[file_instance_id])
+
+    assert first["summary"]["applied_count"] == 1
+    assert second["summary"]["applied_count"] == 0
+    assert not recycle_path.exists()
+    with session_factory() as session:
+        record = session.get(IntegrityQuarantineRecord, file_instance_id)
+        assert record is not None
+        assert record.purged_at is not None
+        assert record.quarantine_status == IntegrityQuarantineStatus.RECYCLED.value
+
+
+def test_duplicate_purge_resume_after_post_delete_persist_failure(
+    session_factory,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    reclaim_root = tmp_path / "reclaim-root"
+    recycle_root = tmp_path / "recycle-bin-root"
+    monkeypatch.setenv("MEDIA_MANAGER_RECLAIM_ROOT", str(reclaim_root))
+    monkeypatch.setenv("MEDIA_MANAGER_RECYCLE_BIN_ROOT", str(recycle_root))
+    planner = Phase3ActionService(session_factory)
+    base = datetime(2026, 4, 10, 15, 0, tzinfo=UTC)
+    monkeypatch.setattr("media_manager.app.persistence.phase3_actions._utcnow", lambda: base + timedelta(days=8))
+    content_id = UUID("f135b1ed-4dc6-4a0d-88d5-81726006507c")
+    canonical_instance = UUID("f135b1ed-4dc6-4a0d-88d5-817260065071")
+    duplicate_instance = UUID("f135b1ed-4dc6-4a0d-88d5-817260065072")
+    recycle_path = recycle_root / "duplicates" / str(content_id) / f"{duplicate_instance}-copy.jpg"
+    recycle_path.parent.mkdir(parents=True, exist_ok=True)
+    recycle_path.write_bytes(b"copy-data")
+
+    with session_factory.begin() as session:
+        _add_content(session, content_id, "hash-purge-resume-dup", base)
+        session.flush()
+        _add_instance(
+            session,
+            file_instance_id=canonical_instance,
+            content_id=content_id,
+            absolute_path=str(tmp_path / "library" / "main.jpg"),
+            first_seen_at=base,
+        )
+        _add_instance(
+            session,
+            file_instance_id=duplicate_instance,
+            content_id=content_id,
+            absolute_path=str(recycle_path),
+            first_seen_at=base + timedelta(seconds=1),
+        )
+        session.add(
+            DuplicateReclaimRecord(
+                content_id=content_id,
+                reclaim_status=DuplicateReclaimStatus.SCHEDULED_FOR_DELETE.value,
+                reviewed_at=base,
+                reviewed_by="tester",
+                restored_at=None,
+                created_at=base,
+                updated_at=base,
+            )
+        )
+        session.add(
+            DuplicateReclaimItem(
+                file_instance_id=duplicate_instance,
+                content_id=content_id,
+                original_path=str(tmp_path / "library" / "copy.jpg"),
+                archive_path=str(recycle_path),
+                planned_bin_path=None,
+                bin_path=str(recycle_path),
+                item_status=DuplicateReclaimItemStatus.RECYCLED.value,
+                reclaimed_at=base,
+                bin_entered_at=base,
+                expires_at=base + timedelta(days=7),
+                restore_expires_at=base + timedelta(days=7),
+                bin_state=DuplicateBinState.IN_BIN.value,
+                recycle_path=str(recycle_path),
+                recycled_at=base,
+                purge_after_at=base + timedelta(days=7),
+                purged_at=None,
+                restored_at=None,
+                created_at=base,
+                updated_at=base,
+            )
+        )
+
+    run_id = planner._plan_duplicate_purge(file_instance_ids=[duplicate_instance])
+    assert run_id is not None
+    apply_service = ApplyService(session_factory)
+    persist_failed = False
+    real_persist = apply_service._persist_applied_action
+
+    def _fail_once(*args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal persist_failed
+        if not persist_failed:
+            persist_failed = True
+            raise RuntimeError("simulated persist failure after delete")
+        return real_persist(*args, **kwargs)
+
+    monkeypatch.setattr(apply_service, "_persist_applied_action", _fail_once)
+
+    with pytest.raises(RuntimeError, match="simulated persist failure after delete"):
+        apply_service.apply_run(run_id)
+
+    assert not recycle_path.exists()
+    resumed = ApplyService(session_factory).apply_run(run_id)
+    assert resumed.applied_count == 1
+    with session_factory() as session:
+        run = session.get(Run, run_id)
+        assert run is not None
+        assert run.state == RunStateDB.COMPLETED
+        item = session.get(DuplicateReclaimItem, duplicate_instance)
+        assert item is not None
+        assert item.bin_state == DuplicateBinState.PURGED.value
+        assert item.purged_at is not None
+        failure = session.scalar(
+            select(FailureEvent).where(
+                FailureEvent.run_id == run_id,
+                FailureEvent.error_code == "APPLY_FAILED",
+            )
+        )
+        assert failure is not None
+
+
+def test_integrity_purge_resume_after_post_delete_persist_failure(
+    session_factory,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    reclaim_root = tmp_path / "reclaim-root"
+    recycle_root = tmp_path / "recycle-bin-root"
+    quarantine_root = tmp_path / "quarantine-root"
+    monkeypatch.setenv("MEDIA_MANAGER_RECLAIM_ROOT", str(reclaim_root))
+    monkeypatch.setenv("MEDIA_MANAGER_RECYCLE_BIN_ROOT", str(recycle_root))
+    monkeypatch.setenv("MEDIA_MANAGER_INTEGRITY_QUARANTINE_ROOT", str(quarantine_root))
+    planner = Phase3ActionService(session_factory)
+    base = datetime(2026, 4, 10, 16, 0, tzinfo=UTC)
+    monkeypatch.setattr("media_manager.app.persistence.phase3_actions._utcnow", lambda: base + timedelta(days=15))
+    file_instance_id = UUID("0135b1ed-4dc6-4a0d-88d5-817260065072")
+    content_id = UUID("0135b1ed-4dc6-4a0d-88d5-81726006507c")
+    check_id = UUID("0135b1ed-4dc6-4a0d-88d5-817260065073")
+    check_run_id = UUID("0135b1ed-4dc6-4a0d-88d5-817260065074")
+    recycle_path = recycle_root / "integrity" / f"{file_instance_id}-broken.jpg"
+    recycle_path.parent.mkdir(parents=True, exist_ok=True)
+    recycle_path.write_bytes(b"broken")
+
+    with session_factory.begin() as session:
+        _add_content(session, content_id, "hash-purge-resume-int", base)
+        session.flush()
+        _add_instance(
+            session,
+            file_instance_id=file_instance_id,
+            content_id=content_id,
+            absolute_path=str(recycle_path),
+            first_seen_at=base,
+        )
+        session.add(
+            IntegrityCheckRun(
+                id=check_run_id,
+                scan_mode="DEEP",
+                status="COMPLETED",
+                paths=[str(tmp_path / "library")],
+                scanned_count=1,
+                issues_found=1,
+            )
+        )
+        session.flush()
+        session.add(
+            IntegrityCheck(
+                id=check_id,
+                file_instance_id=file_instance_id,
+                latest_run_id=check_run_id,
+                status="BROKEN",
+            )
+        )
+        session.flush()
+        session.add(
+            IntegrityQuarantineRecord(
+                file_instance_id=file_instance_id,
+                check_id=check_id,
+                original_path=str(tmp_path / "library" / "broken.jpg"),
+                quarantine_path=str(quarantine_root / f"{file_instance_id}-broken.jpg"),
+                quarantine_status=IntegrityQuarantineStatus.RECYCLED.value,
+                quarantined_at=base,
+                expires_at=base + timedelta(days=7),
+                recycle_path=str(recycle_path),
+                recycled_at=base + timedelta(days=7),
+                purge_after_at=base + timedelta(days=14),
+                purged_at=None,
+                restored_at=None,
+                created_at=base,
+                updated_at=base,
+            )
+        )
+
+    run_id = planner._plan_integrity_purge(file_instance_ids=[file_instance_id])
+    assert run_id is not None
+    apply_service = ApplyService(session_factory)
+    persist_failed = False
+    real_persist = apply_service._persist_applied_action
+
+    def _fail_once(*args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal persist_failed
+        if not persist_failed:
+            persist_failed = True
+            raise RuntimeError("simulated persist failure after delete")
+        return real_persist(*args, **kwargs)
+
+    monkeypatch.setattr(apply_service, "_persist_applied_action", _fail_once)
+
+    with pytest.raises(RuntimeError, match="simulated persist failure after delete"):
+        apply_service.apply_run(run_id)
+
+    assert not recycle_path.exists()
+    resumed = ApplyService(session_factory).apply_run(run_id)
+    assert resumed.applied_count == 1
+    with session_factory() as session:
+        run = session.get(Run, run_id)
+        assert run is not None
+        assert run.state == RunStateDB.COMPLETED
+        record = session.get(IntegrityQuarantineRecord, file_instance_id)
+        assert record is not None
+        assert record.purged_at is not None
+        assert record.quarantine_status == IntegrityQuarantineStatus.RECYCLED.value
+        failure = session.scalar(
+            select(FailureEvent).where(
+                FailureEvent.run_id == run_id,
+                FailureEvent.error_code == "APPLY_FAILED",
+            )
+        )
+        assert failure is not None
+
+
+def test_plan_duplicate_reclaim_reentry_resets_reclaimed_at(
+    session_factory,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    reclaim_root = tmp_path / "reclaim-root"
+    recycle_root = tmp_path / "recycle-bin-root"
+    monkeypatch.setenv("MEDIA_MANAGER_RECLAIM_ROOT", str(reclaim_root))
+    monkeypatch.setenv("MEDIA_MANAGER_RECYCLE_BIN_ROOT", str(recycle_root))
+    service = Phase3ActionService(session_factory)
+    base = datetime(2026, 4, 10, 17, 0, tzinfo=UTC)
+    now = base + timedelta(minutes=5)
+    monkeypatch.setattr("media_manager.app.persistence.phase3_actions._utcnow", lambda: now)
+
+    content_id = UUID("1135b1ed-4dc6-4a0d-88d5-81726006507c")
+    canonical_instance = UUID("1135b1ed-4dc6-4a0d-88d5-817260065071")
+    duplicate_instance = UUID("1135b1ed-4dc6-4a0d-88d5-817260065072")
+    source_path = tmp_path / "library" / "copy.jpg"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_bytes(b"copy")
+
+    with session_factory.begin() as session:
+        _add_content(session, content_id, "hash-reentry-dup", base)
+        session.flush()
+        _add_instance(
+            session,
+            file_instance_id=canonical_instance,
+            content_id=content_id,
+            absolute_path=str(tmp_path / "library" / "main.jpg"),
+            first_seen_at=base,
+        )
+        _add_instance(
+            session,
+            file_instance_id=duplicate_instance,
+            content_id=content_id,
+            absolute_path=str(source_path),
+            first_seen_at=base + timedelta(seconds=1),
+        )
+        session.flush()
+        fc = session.get(FileContent, content_id)
+        assert fc is not None
+        fc.canonical_file_instance_id = canonical_instance
+        session.add(
+            DuplicateReclaimRecord(
+                content_id=content_id,
+                reclaim_status=DuplicateReclaimStatus.REVIEWED_SAFE_TO_RECLAIM.value,
+                reviewed_at=base,
+                reviewed_by="tester",
+                restored_at=None,
+                created_at=base,
+                updated_at=base,
+            )
+        )
+        session.add(
+            DuplicateReclaimItem(
+                file_instance_id=duplicate_instance,
+                content_id=content_id,
+                original_path=str(source_path),
+                archive_path=str(recycle_root / "old-copy.jpg"),
+                planned_bin_path=None,
+                bin_path=None,
+                item_status=DuplicateReclaimItemStatus.RECYCLED.value,
+                reclaimed_at=base - timedelta(days=30),
+                bin_entered_at=base - timedelta(days=30),
+                expires_at=base - timedelta(days=15),
+                restore_expires_at=base - timedelta(days=15),
+                bin_state=DuplicateBinState.PURGED.value,
+                recycle_path=None,
+                recycled_at=base - timedelta(days=20),
+                purge_after_at=base - timedelta(days=10),
+                purged_at=base - timedelta(days=9),
+                restored_at=base - timedelta(days=8),
+                created_at=base - timedelta(days=30),
+                updated_at=base - timedelta(days=9),
+            )
+        )
+
+    result = service._plan_duplicate_reclaim(content_ids=[content_id], retention_days=7)
+    assert result["diagnostics"]["planned_action_count"] == 1
+    with session_factory() as session:
+        item = session.get(DuplicateReclaimItem, duplicate_instance)
+        assert item is not None
+        assert item.item_status == DuplicateReclaimItemStatus.PENDING.value
+        assert item.reclaimed_at is None
+        assert item.bin_entered_at is None
+        assert item.purged_at is None
+        assert item.restored_at is None
+
+
+def test_plan_integrity_quarantine_reentry_resets_quarantine_timestamps(
+    session_factory,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    reclaim_root = tmp_path / "reclaim-root"
+    recycle_root = tmp_path / "recycle-bin-root"
+    quarantine_root = tmp_path / "quarantine-root"
+    monkeypatch.setenv("MEDIA_MANAGER_RECLAIM_ROOT", str(reclaim_root))
+    monkeypatch.setenv("MEDIA_MANAGER_RECYCLE_BIN_ROOT", str(recycle_root))
+    monkeypatch.setenv("MEDIA_MANAGER_INTEGRITY_QUARANTINE_ROOT", str(quarantine_root))
+    service = Phase3ActionService(session_factory)
+    base = datetime(2026, 4, 10, 18, 0, tzinfo=UTC)
+    now = base + timedelta(minutes=5)
+    monkeypatch.setattr("media_manager.app.persistence.phase3_actions._utcnow", lambda: now)
+
+    file_instance_id = UUID("2135b1ed-4dc6-4a0d-88d5-817260065072")
+    content_id = UUID("2135b1ed-4dc6-4a0d-88d5-81726006507c")
+    check_id = UUID("2135b1ed-4dc6-4a0d-88d5-817260065073")
+    check_run_id = UUID("2135b1ed-4dc6-4a0d-88d5-817260065074")
+
+    with session_factory.begin() as session:
+        _add_content(session, content_id, "hash-reentry-int", base)
+        session.flush()
+        _add_instance(
+            session,
+            file_instance_id=file_instance_id,
+            content_id=content_id,
+            absolute_path=str(tmp_path / "library" / "broken.jpg"),
+            first_seen_at=base,
+        )
+        session.add(
+            IntegrityCheckRun(
+                id=check_run_id,
+                scan_mode="DEEP",
+                status="COMPLETED",
+                paths=[str(tmp_path / "library")],
+                scanned_count=1,
+                issues_found=1,
+            )
+        )
+        session.flush()
+        session.add(
+            IntegrityCheck(
+                id=check_id,
+                file_instance_id=file_instance_id,
+                latest_run_id=check_run_id,
+                status="BROKEN",
+            )
+        )
+        session.flush()
+        session.add(
+            IntegrityQuarantineRecord(
+                file_instance_id=file_instance_id,
+                check_id=check_id,
+                original_path=str(tmp_path / "library" / "broken.jpg"),
+                quarantine_path=str(quarantine_root / f"{file_instance_id}-broken.jpg"),
+                quarantine_status=IntegrityQuarantineStatus.RECYCLED.value,
+                quarantined_at=base - timedelta(days=10),
+                expires_at=base - timedelta(days=5),
+                recycle_path=str(recycle_root / "integrity" / "old-broken.jpg"),
+                recycled_at=base - timedelta(days=8),
+                purge_after_at=base - timedelta(days=2),
+                purged_at=base - timedelta(days=1),
+                restored_at=base - timedelta(days=3),
+                created_at=base - timedelta(days=10),
+                updated_at=base - timedelta(days=1),
+            )
+        )
+
+    run_id = service._plan_integrity_quarantine(check_id=check_id)
+    assert run_id is not None
+    with session_factory() as session:
+        record = session.get(IntegrityQuarantineRecord, file_instance_id)
+        assert record is not None
+        assert record.quarantine_status == IntegrityQuarantineStatus.PENDING.value
+        assert record.quarantined_at is None
+        assert record.restored_at is None
+        assert record.purged_at is None


### PR DESCRIPTION
- keep purge status model consistent with constraints (bin_state/purged_at markers)

- reset duplicate/integrity re-entry timestamps in planner update paths

- make new-row planner constructors explicit with purged_at=None

- harden purge planner tests with non-null run_id assertions

- add purge idempotency/resume and re-entry reset coverage

- prevent operator console from resolving stale recycled paths for purged items
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
