### PR TITLE
feat(gui): compact duplicate-review shared shell above tabs

### DIFF
--- a/operator_console/gui_app/src/pages/DuplicatesPage.tsx
+++ b/operator_console/gui_app/src/pages/DuplicatesPage.tsx
@@ -119,6 +119,13 @@ const binStateLabels = {
   wontPlay: "Won't play",
 } as const;
 
+const tabHeadingLabels: Record<DuplicatesTab, string> = {
+  review: "Review duplicates",
+  "ready-for-bin": "Ready for Bin",
+  "recycle-bin": "Recycle Bin",
+  "playback-issues": "Playback issues",
+};
+
 const recommendationStateLabels: Record<DuplicateRecommendation["state"], string> = {
   SAFE_TO_MOVE_EXTRAS: "Safe to move extra copies",
   REVIEW_REQUIRED: "Review required",
@@ -1483,8 +1490,8 @@ export default function DuplicatesPage() {
       className={cn(
         "mx-auto flex flex-col",
         activeTab === "review"
-          ? "max-w-[120rem] gap-3 px-2 py-3 sm:px-2.5 lg:px-3"
-          : "max-w-[120rem] gap-4 px-3 py-4 sm:px-4 lg:px-5",
+          ? "max-w-[120rem] gap-2.5 px-2 py-2.5 sm:px-2.5 lg:px-3"
+          : "max-w-[120rem] gap-3 px-3 py-3 sm:px-4 lg:px-5",
       )}
     >
       <div data-page-header data-testid="duplicates-page-header">
@@ -1493,9 +1500,9 @@ export default function DuplicatesPage() {
           title="Work duplicate decisions in focused steps."
           description="Compare duplicates, move extra copies to the Recycle Bin, restore them if needed, and keep playback review separate."
           icon={Copy}
-          density={activeTab === "review" ? "compact" : "default"}
-          className={activeTab === "review" ? "rounded-[24px]" : undefined}
-          contentClassName={activeTab === "review" ? "px-4 py-3 sm:px-4 lg:px-5 lg:py-4" : undefined}
+          density="compact"
+          className="rounded-[24px]"
+          contentClassName="px-4 py-3 sm:px-4 lg:px-5 lg:py-4"
         />
       </div>
 
@@ -1531,7 +1538,7 @@ export default function DuplicatesPage() {
           description="When duplicate files are found, they will appear here for side-by-side review."
         />
       ) : (
-        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as DuplicatesTab)} className="space-y-4">
+        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as DuplicatesTab)} className="space-y-3">
           <section
             data-page-controls
             data-testid="duplicates-page-controls"
@@ -1545,35 +1552,9 @@ export default function DuplicatesPage() {
             </TabsList>
           </section>
 
-          <Card className={cn("rounded-[24px] border-border/70 bg-card/95 shadow-sm", activeTab === "review" && "shadow-none")}>
-            <CardContent className={cn("space-y-4 p-4", activeTab === "review" && "space-y-3 p-2.5 sm:p-3")}>
-              <TabsContent value="review" className="mt-0">
-                <div className="space-y-2">
-                  <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-                    <div>
-                      <h2 className="text-lg font-semibold tracking-tight text-foreground">Review duplicates</h2>
-                      <p className="mt-1 text-sm text-muted-foreground">
-                        Compare one group at a time, follow the system recommendation, and keep your own review decision separate.
-                      </p>
-                    </div>
-                    <p className="text-sm text-muted-foreground">{reviewProgressLabel} in sequence</p>
-                  </div>
-                </div>
-              </TabsContent>
-
-              <TabsContent value="ready-for-bin" className="mt-0">
-                <h2 className="text-xl font-semibold tracking-tight text-foreground">Ready for Bin</h2>
-              </TabsContent>
-
-              <TabsContent value="recycle-bin" className="mt-0">
-                <h2 className="text-xl font-semibold tracking-tight text-foreground">Recycle Bin</h2>
-              </TabsContent>
-
-              <TabsContent value="playback-issues" className="mt-0">
-                <h2 className="text-xl font-semibold tracking-tight text-foreground">Playback issues</h2>
-              </TabsContent>
-            </CardContent>
-          </Card>
+          <div data-testid="duplicates-shared-tab-heading" className="px-1">
+            <h2 className="text-xl font-semibold tracking-tight text-foreground">{tabHeadingLabels[activeTab]}</h2>
+          </div>
 
           <TabsContent value="review" className="mt-0">
             <div className="space-y-3">

--- a/operator_console/gui_app/src/test/duplicates-page.test.tsx
+++ b/operator_console/gui_app/src/test/duplicates-page.test.tsx
@@ -302,6 +302,9 @@ describe("DuplicatesPage", () => {
     expect(within(pageControls).getByRole("tab", { name: "Ready for Bin" })).toBeInTheDocument();
     expect(within(pageControls).getByRole("tab", { name: "Recycle Bin" })).toBeInTheDocument();
     expect(within(pageControls).getByRole("tab", { name: "Playback issues" })).toBeInTheDocument();
+    const sharedHeading = screen.getByTestId("duplicates-shared-tab-heading");
+    expect(pageControls.nextElementSibling).toBe(sharedHeading);
+    expect(sharedHeading).toHaveTextContent("Review duplicates");
 
     expect(await screen.findByRole("heading", { name: "Review duplicates" })).toBeInTheDocument();
     expect(screen.getByTestId("review-group-navigation-hidden")).toBeInTheDocument();
@@ -512,6 +515,10 @@ describe("DuplicatesPage", () => {
 
     renderPage("/duplicates?tab=removal");
 
+    const pageControls = await screen.findByTestId("duplicates-page-controls");
+    const sharedHeading = screen.getByTestId("duplicates-shared-tab-heading");
+    expect(pageControls.nextElementSibling).toBe(sharedHeading);
+    expect(sharedHeading).toHaveTextContent("Ready for Bin");
     expect(await screen.findByRole("heading", { name: "Ready for Bin" })).toBeInTheDocument();
     expect(screen.getAllByText("Ready for Bin").length).toBeGreaterThan(0);
     expect(await screen.findByTestId("ready-for-bin-top-controls")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Refactors the shared Duplicate Review shell above the tabs so operators reach active tab content sooner.

This PR is intentionally limited to the shared page-level structure in `DuplicatesPage.tsx`. It does not reopen the internal layout work already completed for Review duplicates, Ready for Bin, Recycle Bin, or Playback Issues.

## What changed

### Shared shell structure
- compacted the shared `TopSurfaceHeader`
- tightened page-level spacing around the header and tabs
- removed the old shared per-tab heading card between the tab strip and tab-specific content
- replaced it with one minimal shared active-tab heading
- preserved `duplicates-page-controls` and tab-strip behavior

### Behavior preserved
Kept existing:
- tab labels and routing
- tab navigation behavior
- all tab-internal workflows
- error banner placement
- loading and empty states
- keyboard shortcuts and review actions

### Scope protection
Did not change:
- Review duplicates internals
- Ready for Bin internals
- Recycle Bin internals
- Playback Issues internals
- backend/API/model behavior
- loading/query logic
- error alert logic or placement

## Tests

Updated:
- operator_console/gui_app/src/test/duplicates-page.test.tsx

Validation run:
cd operator_console/gui_app && npm run test -- src/test/duplicates-page.test.tsx

Result:
- passing

## Why this PR is intentionally narrow

This is the remaining shared-shell cleanup slice under issue #12 after the tab-level Duplicate Review improvements. It is designed to reduce leftover shared chrome without reopening completed tab internals.

## Related

- #88
- #12
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
