### PR TITLE
feat(gui): add Library media-type filter

### DIFF
--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -142,6 +142,7 @@ export default function GalleryPage() {
     () => items.filter((item) => mediaTypeFilter === "all" || item.file_type === mediaTypeFilter),
     [items, mediaTypeFilter],
   );
+  const visibleCount = visibleItems.length;
   const allTags = useMemo(() => (tagsQuery.data as Tag[] | undefined) ?? [], [tagsQuery.data]);
   const totalCount = data?.total_count ?? 0;
   const totalPages = Math.max(data?.total_pages ?? 1, 1);
@@ -179,7 +180,7 @@ export default function GalleryPage() {
           <div className="rounded-2xl border border-border/70 bg-background/85 px-4 py-3 text-sm text-muted-foreground shadow-sm">
             {galleryQuery.isLoading && !data
               ? "Loading gallery..."
-              : `${totalCount} item${totalCount === 1 ? "" : "s"} · Page ${page} of ${totalPages}`}
+              : `${mediaTypeFilter !== "all" ? visibleCount : totalCount} item${(mediaTypeFilter !== "all" ? visibleCount : totalCount) === 1 ? "" : "s"} · Page ${page} of ${totalPages}`}
           </div>
         </div>
 

--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Pagination, PaginationContent, PaginationEllipsis, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
 import { Slider } from "@/components/ui/slider";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { getCanonical, getCanonicalTags } from "@/lib/api/endpoints";
 import { queryKeys } from "@/lib/api/queryKeys";
 import { queryOptions } from "@/lib/api/queryOptions";
@@ -49,9 +50,14 @@ const DENSITY_PRESETS = [
 ] as const;
 
 type DensityKey = (typeof DENSITY_PRESETS)[number]["key"];
+type MediaTypeFilter = "all" | "image" | "video";
 
 function getDensityPreset(densityParam: string | null) {
   return DENSITY_PRESETS.find((preset) => preset.key === densityParam) ?? DENSITY_PRESETS[1];
+}
+
+function getMediaTypeFilter(mediaTypeParam: string | null): MediaTypeFilter {
+  return mediaTypeParam === "image" || mediaTypeParam === "video" ? mediaTypeParam : "all";
 }
 
 function getVisiblePages(currentPage: number, totalPages: number): Array<number | "ellipsis"> {
@@ -82,6 +88,7 @@ export default function GalleryPage() {
   const sortOrder = searchParams.get("sort_order") || "desc";
   const page = Math.max(1, Number(searchParams.get("page") || 1));
   const densityPreset = getDensityPreset(searchParams.get("density"));
+  const mediaTypeFilter = getMediaTypeFilter(searchParams.get("media_type"));
   const densityIndex = DENSITY_PRESETS.findIndex((preset) => preset.key === densityPreset.key);
 
   const updateParams = (updates: Record<string, string | undefined>) => {
@@ -131,6 +138,10 @@ export default function GalleryPage() {
 
   const data = (galleryQuery.data as PaginatedResponse<CanonicalFile> | undefined) ?? null;
   const items = data?.items ?? [];
+  const visibleItems = useMemo(
+    () => items.filter((item) => mediaTypeFilter === "all" || item.file_type === mediaTypeFilter),
+    [items, mediaTypeFilter],
+  );
   const allTags = useMemo(() => (tagsQuery.data as Tag[] | undefined) ?? [], [tagsQuery.data]);
   const totalCount = data?.total_count ?? 0;
   const totalPages = Math.max(data?.total_pages ?? 1, 1);
@@ -174,6 +185,34 @@ export default function GalleryPage() {
 
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-1 flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium text-foreground">Media type</span>
+              <ToggleGroup
+                type="single"
+                value={mediaTypeFilter}
+                onValueChange={(value) => {
+                  if (value !== "all" && value !== "image" && value !== "video") return;
+                  updateParams({
+                    media_type: value === "all" ? undefined : value,
+                    page: "1",
+                  });
+                }}
+                variant="outline"
+                size="sm"
+                aria-label="Filter library by media type"
+              >
+                <ToggleGroupItem value="all" aria-label="All" data-testid="gallery-media-type-all">
+                  All
+                </ToggleGroupItem>
+                <ToggleGroupItem value="image" aria-label="Images" data-testid="gallery-media-type-images">
+                  Images
+                </ToggleGroupItem>
+                <ToggleGroupItem value="video" aria-label="Videos" data-testid="gallery-media-type-videos">
+                  Videos
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+
             <div className="relative max-w-md">
               <Input
                 value={tagInput}
@@ -297,15 +336,15 @@ export default function GalleryPage() {
 
       <div data-page-primary-surface className="-mt-1 space-y-5">
         <MediaGrid
-          files={items}
+          files={visibleItems}
           loading={galleryQuery.isLoading && !data}
           gridClassName={densityPreset.gridClassName}
           skeletonCount={densityPreset.limit}
           density={densityPreset.key}
           emptyTitle="No media files"
           emptyDescription={
-            selectedTags.length
-              ? "Try adjusting your tag filters or sort order."
+            selectedTags.length || mediaTypeFilter !== "all"
+              ? "Try adjusting your tag filters, media type, or sort order."
               : "Run an ingest to populate the gallery."
           }
           onPreview={setSelectedFile}

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -148,4 +148,41 @@ describe("Gallery page", () => {
       expect(screen.getByText("clip.mp4")).toBeInTheDocument();
     });
   });
+
+  it("updates status count to show filtered count when media type changes", async () => {
+    mocks.getCanonical.mockResolvedValue({
+      data: {
+        items: [
+          { id: "v1", filename: "v1.jpg", file_type: "image", media_url: "/v1", poster_url: null, matched_tags: [], top_confidence_score: 0.9, sort_tag_name: null },
+          { id: "v2", filename: "v2.mp4", file_type: "video", media_url: "/v2", poster_url: "/v2", matched_tags: [], top_confidence_score: 0.9, sort_tag_name: null },
+        ],
+        total_count: 2,
+        page: 1,
+        limit: 20,
+        total_pages: 1,
+      },
+    });
+
+    renderPage();
+
+    await screen.findByText("2 items · Page 1 of 1");
+
+    fireEvent.click(screen.getByRole("radio", { name: "Images" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("1 item · Page 1 of 1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: "Videos" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("1 item · Page 1 of 1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: "All" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("2 items · Page 1 of 1")).toBeInTheDocument();
+    });
+  });
 });

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -58,8 +58,18 @@ describe("Gallery page", () => {
             top_confidence_score: 0.94,
             sort_tag_name: "travel",
           },
+          {
+            id: "video-1",
+            filename: "clip.mp4",
+            file_type: "video",
+            media_url: "/media/video-1",
+            poster_url: "/poster/video-1",
+            matched_tags: ["family"],
+            top_confidence_score: 0.88,
+            sort_tag_name: "family",
+          },
         ],
-        total_count: 1,
+        total_count: 2,
         page: 1,
         limit: 20,
         total_pages: 1,
@@ -81,9 +91,15 @@ describe("Gallery page", () => {
     expect(document.querySelector('[data-page-shell="browse-list"]')).toBeTruthy();
     expect(document.querySelector("[data-page-shell-controls]")).toBeTruthy();
     expect(document.querySelector("[data-page-primary-surface]")).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "All" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Images" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Videos" })).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Filter gallery by tag")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Descending" })).toBeInTheDocument();
-    expect(await screen.findByText("1 item · Page 1 of 1")).toBeInTheDocument();
+    expect(await screen.findByText("2 items · Page 1 of 1")).toBeInTheDocument();
+    expect(screen.getByText("first.jpg")).toBeInTheDocument();
+    expect(screen.getByText("clip.mp4")).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "All" })).toHaveAttribute("aria-checked", "true");
   });
 
   it("keeps filter controls interactive inside the shell controls row", async () => {
@@ -103,5 +119,33 @@ describe("Gallery page", () => {
         sort_order: "desc",
       }),
     );
+  });
+
+  it("filters visible library items by media type", async () => {
+    renderPage();
+
+    await screen.findByText("first.jpg");
+    expect(screen.getByText("clip.mp4")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Images" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("first.jpg")).toBeInTheDocument();
+      expect(screen.queryByText("clip.mp4")).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: "Videos" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("first.jpg")).not.toBeInTheDocument();
+      expect(screen.getByText("clip.mp4")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: "All" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("first.jpg")).toBeInTheDocument();
+      expect(screen.getByText("clip.mp4")).toBeInTheDocument();
+    });
   });
 });

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@/components/ui/slider", () => ({
   ),
 }));
 
-function renderPage() {
+function renderPage(initialEntries?: string[]) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -32,7 +32,7 @@ function renderPage() {
   });
 
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <QueryClientProvider client={queryClient}>
         <GalleryPage />
       </QueryClientProvider>
@@ -146,6 +146,46 @@ describe("Gallery page", () => {
     await waitFor(() => {
       expect(screen.getByText("first.jpg")).toBeInTheDocument();
       expect(screen.getByText("clip.mp4")).toBeInTheDocument();
+    });
+  });
+
+  it("resets to page 1 when media type filter changes", async () => {
+    mocks.getCanonical.mockResolvedValue({
+      data: {
+        items: Array.from({ length: 20 }, (_, i) => ({
+          id: `img-${i}`,
+          filename: `img-${i}.jpg`,
+          file_type: i % 2 === 0 ? "image" : "video",
+          media_url: `/img-${i}`,
+          poster_url: i % 2 === 1 ? `/poster-${i}` : null,
+          matched_tags: [],
+          top_confidence_score: 0.9,
+          sort_tag_name: null,
+        })),
+        total_count: 20,
+        page: 2,
+        limit: 10,
+        total_pages: 2,
+      },
+    });
+
+    renderPage(["/gallery?page=2&media_type=image"]);
+
+    await screen.findByText("img-10.jpg");
+    expect(mocks.getCanonical).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        page: 2,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "Videos" }));
+
+    await waitFor(() => {
+      expect(mocks.getCanonical).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page: 1,
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a narrow media-type filter to the Library page so operators can explicitly browse **All**, **Images**, or **Videos**.

This PR is intentionally limited to `GalleryPage.tsx` and its page-level tests. It does not change usable-default browsing rules, Integrity routing, backend filtering, or broader Library redesign behavior.

## What changed

### Library filtering
- added a visible media-type filter with:
  - All
  - Images
  - Videos
- defaulted the filter to All
- reused the existing item media discriminator already available in page data
- filtered visible items client-side from the existing fetched page data only
- persisted filter state locally in the existing query-param pattern using `media_type`
- reset pagination to page 1 on filter change as the smallest safe local handling

### Behavior preserved
Kept existing:
- sort behavior
- tag filtering
- density/view behavior
- preview behavior
- item rendering
- page shell structure
- backend/API/model behavior

### Scope protection
Did not change:
- usable-default browsing rules
- broken/unplayable/integrity-failed item handling
- Integrity routing or Integrity messaging
- backend filtering or API params
- any page other than `GalleryPage.tsx`

## Tests

Updated:
- `operator_console/gui_app/src/test/gallery-page.test.tsx`

Validation run:
cd operator_console/gui_app && npm run test -- src/test/gallery-page.test.tsx

Result:
- passing

## Why this PR is intentionally narrow

This is the first executable child slice under #91. It isolates media-type filtering from the broader Library redesign / policy work so the change can land cleanly without reopening undefined usable-default or Integrity-routing behavior.

## Related

- #91
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
