### PR TITLE
fix(library): server-side media-type filtering with truthful pagination (#94)

### DIFF
--- a/media_manager/app/service_layer/reads.py
+++ b/media_manager/app/service_layer/reads.py
@@ -271,6 +271,7 @@ class ReadServices:
         tags: tuple[str, ...],
         sort_by: str,
         sort_order: str | None,
+        file_type: str | None,
         source: str | None,
         min_confidence: float | None,
     ) -> dict[str, object]:
@@ -281,6 +282,7 @@ class ReadServices:
             tags=tags,
             sort_by=sort_by,
             sort_order=sort_order,
+            file_type=file_type,
             source=source_value,
             min_confidence=min_confidence,
         ).to_dict()

--- a/media_manager/tests/test_operator_console_canonical_gallery.py
+++ b/media_manager/tests/test_operator_console_canonical_gallery.py
@@ -432,6 +432,43 @@ def test_get_canonical_gallery_supports_source_filter(session_factory) -> None:
     assert page.items[0].id == str(b_id)
 
 
+def test_get_canonical_gallery_paginates_filtered_media_type_dataset(session_factory) -> None:
+    service = OperatorConsoleReadService(session_factory)
+    base = datetime(2026, 3, 2, 13, 42, tzinfo=UTC)
+
+    with session_factory.begin() as session:
+        for idx, suffix in enumerate(("a.jpg", "b.mp4", "c.jpg", "d.mp4")):
+            content_id = UUID(f"65100000-0000-0000-0000-00000000000{idx}")
+            instance_id = UUID(f"66100000-0000-0000-0000-00000000000{idx}")
+            _add_content(session, content_id, f"hash-filter-{idx}", base + timedelta(seconds=idx))
+            session.flush()
+            _add_instance(
+                session,
+                file_instance_id=instance_id,
+                content_id=content_id,
+                absolute_path=f"/gallery/{suffix}",
+                first_seen_at=base + timedelta(seconds=idx),
+            )
+            _add_assignment(
+                session,
+                assignment_id=UUID(f"67100000-0000-0000-0000-00000000000{idx}"),
+                content_id=content_id,
+                canonical_instance_id=instance_id,
+                assigned_at=base + timedelta(seconds=idx),
+            )
+
+    page1 = service.get_canonical_gallery(page=1, limit=1, file_type="image")
+    page2 = service.get_canonical_gallery(page=2, limit=1, file_type="image")
+    videos = service.get_canonical_gallery(page=1, limit=5, file_type="video")
+
+    assert page1.total_count == 2
+    assert page1.total_pages == 2
+    assert [item.filename for item in page1.items] == ["c.jpg"]
+    assert [item.filename for item in page2.items] == ["a.jpg"]
+    assert videos.total_count == 2
+    assert {item.filename for item in videos.items} == {"b.mp4", "d.mp4"}
+
+
 def test_get_canonical_gallery_created_at_tie_breaks_by_content_id(session_factory) -> None:
     service = OperatorConsoleReadService(session_factory)
     base = datetime(2026, 3, 2, 13, 45, tzinfo=UTC)

--- a/media_manager/tests/test_service_layer_reads.py
+++ b/media_manager/tests/test_service_layer_reads.py
@@ -41,6 +41,40 @@ def test_duplicate_bin_items_reuses_reclaim_archive_page(monkeypatch: pytest.Mon
     assert payload["items"][0]["item_status"] == "ARCHIVED"
 
 
+def test_canonical_reuses_gallery_page_with_file_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeOperatorConsoleReadService:
+        def __init__(self, _session_factory) -> None:
+            pass
+
+        def get_canonical_gallery(self, **kwargs):  # type: ignore[no-untyped-def]
+            assert kwargs["page"] == 1
+            assert kwargs["limit"] == 10
+            assert kwargs["tags"] == ("travel",)
+            assert kwargs["sort_by"] == "created_at"
+            assert kwargs["sort_order"] == "desc"
+            assert kwargs["file_type"] == "image"
+            assert kwargs["source"] is None
+            assert kwargs["min_confidence"] is None
+            return type("Page", (), {"to_dict": lambda self: {"page": 1, "limit": 10, "total_count": 1, "total_pages": 1, "items": []}})()
+
+    monkeypatch.setattr(reads_module, "OperatorConsoleReadService", _FakeOperatorConsoleReadService)
+
+    services = ReadServices(session_factory=object(), cache=_FakeCache(invalidations=[]))  # type: ignore[arg-type]
+
+    payload = services.canonical(
+        page=1,
+        limit=10,
+        tags=("travel",),
+        sort_by="created_at",
+        sort_order="desc",
+        file_type="image",
+        source=None,
+        min_confidence=None,
+    )
+
+    assert payload["total_count"] == 1
+
+
 def test_admin_app_settings_returns_persisted_non_sensitive_metadata(session_factory) -> None:
     AppSettingsService(session_factory).set_value(
         "video_thumbnails_enabled",

--- a/operator_console/gui_app/src/lib/api/endpoints/media.ts
+++ b/operator_console/gui_app/src/lib/api/endpoints/media.ts
@@ -15,6 +15,7 @@ import {
   mapTagItems,
 } from "@/lib/api/mappers/media";
 import { mapPagination } from "@/lib/api/pagination";
+import type { MediaType } from "@/lib/api/queryKeys";
 
 export const getCanonical = async (params?: {
   page?: number;
@@ -22,7 +23,7 @@ export const getCanonical = async (params?: {
   tags?: string;
   sort_by?: string;
   sort_order?: string;
-  media_type?: "image" | "video";
+  media_type?: MediaType;
 }) => {
   const envelope = await apiGet<Record<string, unknown>>(
     "/canonical",

--- a/operator_console/gui_app/src/lib/api/endpoints/media.ts
+++ b/operator_console/gui_app/src/lib/api/endpoints/media.ts
@@ -22,6 +22,7 @@ export const getCanonical = async (params?: {
   tags?: string;
   sort_by?: string;
   sort_order?: string;
+  media_type?: "image" | "video";
 }) => {
   const envelope = await apiGet<Record<string, unknown>>(
     "/canonical",

--- a/operator_console/gui_app/src/lib/api/queryKeys.ts
+++ b/operator_console/gui_app/src/lib/api/queryKeys.ts
@@ -1,10 +1,12 @@
+export type MediaType = "image" | "video";
+
 export interface CanonicalQueryParams {
   page?: number;
   limit?: number;
   tags?: string;
   sort_by?: string;
   sort_order?: string;
-  media_type?: "image" | "video";
+  media_type?: MediaType;
 }
 
 export const queryKeys = {

--- a/operator_console/gui_app/src/lib/api/queryKeys.ts
+++ b/operator_console/gui_app/src/lib/api/queryKeys.ts
@@ -4,6 +4,7 @@ export interface CanonicalQueryParams {
   tags?: string;
   sort_by?: string;
   sort_order?: string;
+  media_type?: "image" | "video";
 }
 
 export const queryKeys = {

--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -119,8 +119,9 @@ export default function GalleryPage() {
       tags: tagsParam || undefined,
       sort_by: sortBy,
       sort_order: sortOrder,
+      media_type: mediaTypeFilter === "all" ? undefined : mediaTypeFilter,
     }),
-    [densityPreset.limit, page, sortBy, sortOrder, tagsParam],
+    [densityPreset.limit, mediaTypeFilter, page, sortBy, sortOrder, tagsParam],
   );
 
   const tagsQuery = useQuery({
@@ -138,13 +139,8 @@ export default function GalleryPage() {
 
   const data = (galleryQuery.data as PaginatedResponse<CanonicalFile> | undefined) ?? null;
   const items = data?.items ?? [];
-  const visibleItems = useMemo(
-    () => items.filter((item) => mediaTypeFilter === "all" || item.file_type === mediaTypeFilter),
-    [items, mediaTypeFilter],
-  );
-  const visibleCount = visibleItems.length;
   const allTags = useMemo(() => (tagsQuery.data as Tag[] | undefined) ?? [], [tagsQuery.data]);
-  const totalCount = data?.total_count ?? 0;
+  const totalCount = data?.total ?? 0;
   const totalPages = Math.max(data?.total_pages ?? 1, 1);
   const visiblePages = useMemo(() => getVisiblePages(page, totalPages), [page, totalPages]);
   const hasActiveFilters = selectedTags.length > 0 || mediaTypeFilter !== "all";
@@ -185,7 +181,7 @@ export default function GalleryPage() {
           <div className="rounded-2xl border border-border/70 bg-background/85 px-4 py-3 text-sm text-muted-foreground shadow-sm">
             {galleryQuery.isLoading && !data
               ? "Loading gallery..."
-              : `${mediaTypeFilter !== "all" ? visibleCount : totalCount} item${(mediaTypeFilter !== "all" ? visibleCount : totalCount) === 1 ? "" : "s"} · Page ${page} of ${totalPages}`}
+              : `${totalCount} item${totalCount === 1 ? "" : "s"} · Page ${page} of ${totalPages}`}
           </div>
         </div>
 
@@ -342,7 +338,7 @@ export default function GalleryPage() {
 
       <div data-page-primary-surface className="-mt-1 space-y-5">
         <MediaGrid
-          files={visibleItems}
+          files={items}
           loading={galleryQuery.isLoading && !data}
           gridClassName={densityPreset.gridClassName}
           skeletonCount={densityPreset.limit}

--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
 import { ErrorAlert } from "@/components/ErrorAlert";
@@ -12,6 +12,7 @@ import { Slider } from "@/components/ui/slider";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { getCanonical, getCanonicalTags } from "@/lib/api/endpoints";
 import { queryKeys } from "@/lib/api/queryKeys";
+import type { MediaType } from "@/lib/api/queryKeys";
 import { queryOptions } from "@/lib/api/queryOptions";
 import type { CanonicalFile, PaginatedResponse, Tag } from "@/types";
 import { ArrowUpDown, Grid2X2, LayoutGrid, Loader2, Search, X } from "lucide-react";
@@ -50,7 +51,7 @@ const DENSITY_PRESETS = [
 ] as const;
 
 type DensityKey = (typeof DENSITY_PRESETS)[number]["key"];
-type MediaTypeFilter = "all" | "image" | "video";
+type MediaTypeFilter = "all" | MediaType;
 
 function getDensityPreset(densityParam: string | null) {
   return DENSITY_PRESETS.find((preset) => preset.key === densityParam) ?? DENSITY_PRESETS[1];
@@ -123,6 +124,18 @@ export default function GalleryPage() {
     }),
     [densityPreset.limit, mediaTypeFilter, page, sortBy, sortOrder, tagsParam],
   );
+  const previousCanonicalParamsRef = useRef(canonicalParams);
+  const keepPreviousCanonicalPageData =
+    previousCanonicalParamsRef.current.page !== canonicalParams.page &&
+    previousCanonicalParamsRef.current.limit === canonicalParams.limit &&
+    previousCanonicalParamsRef.current.tags === canonicalParams.tags &&
+    previousCanonicalParamsRef.current.sort_by === canonicalParams.sort_by &&
+    previousCanonicalParamsRef.current.sort_order === canonicalParams.sort_order &&
+    previousCanonicalParamsRef.current.media_type === canonicalParams.media_type;
+
+  useEffect(() => {
+    previousCanonicalParamsRef.current = canonicalParams;
+  }, [canonicalParams]);
 
   const tagsQuery = useQuery({
     queryKey: queryKeys.canonicalTags(""),
@@ -134,7 +147,7 @@ export default function GalleryPage() {
     queryKey: queryKeys.canonical(canonicalParams),
     queryFn: async () => (await getCanonical(canonicalParams)).data,
     staleTime: queryOptions.canonical.staleTime,
-    placeholderData: keepPreviousData,
+    placeholderData: keepPreviousCanonicalPageData ? keepPreviousData : undefined,
   });
 
   const data = (galleryQuery.data as PaginatedResponse<CanonicalFile> | undefined) ?? null;

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -242,6 +242,53 @@ describe("Gallery page", () => {
     });
   });
 
+  it("clears previous page data when media type filter changes", async () => {
+    renderPage();
+
+    await screen.findByText("first.jpg");
+    let resolveFiltered: ((value: unknown) => void) | null = null;
+    mocks.getCanonical.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFiltered = resolve;
+        }),
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "Images" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Loading gallery...")).toBeInTheDocument();
+      expect(screen.queryByText("clip.mp4")).not.toBeInTheDocument();
+    });
+
+    resolveFiltered?.({
+      data: {
+        items: [
+          {
+            id: "image-1",
+            filename: "first.jpg",
+            file_type: "image",
+            media_url: "/media/image-1",
+            poster_url: null,
+            matched_tags: ["travel"],
+            top_confidence_score: 0.94,
+            sort_tag_name: "travel",
+          },
+        ],
+        total: 1,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("first.jpg")).toBeInTheDocument();
+      expect(screen.queryByText("clip.mp4")).not.toBeInTheDocument();
+      expect(screen.getByText("1 item · Page 1 of 1")).toBeInTheDocument();
+    });
+  });
+
   it("composes media type and tag filters", async () => {
     renderPage();
 

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -69,9 +69,9 @@ describe("Gallery page", () => {
             sort_tag_name: "family",
           },
         ],
-        total_count: 2,
+        total: 2,
         page: 1,
-        limit: 20,
+        page_size: 20,
         total_pages: 1,
       },
     });
@@ -121,26 +121,111 @@ describe("Gallery page", () => {
     );
   });
 
-  it("filters visible library items by media type", async () => {
+  it("requests filtered library items by media type", async () => {
     renderPage();
 
     await screen.findByText("first.jpg");
     expect(screen.getByText("clip.mp4")).toBeInTheDocument();
+
+    mocks.getCanonical.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: "image-1",
+            filename: "first.jpg",
+            file_type: "image",
+            media_url: "/media/image-1",
+            poster_url: null,
+            matched_tags: ["travel"],
+            top_confidence_score: 0.94,
+            sort_tag_name: "travel",
+          },
+        ],
+        total: 1,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
+    });
 
     fireEvent.click(screen.getByRole("radio", { name: "Images" }));
 
     await waitFor(() => {
       expect(screen.getByText("first.jpg")).toBeInTheDocument();
       expect(screen.queryByText("clip.mp4")).not.toBeInTheDocument();
+      expect(screen.getByText("1 item · Page 1 of 1")).toBeInTheDocument();
+      expect(mocks.getCanonical).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          media_type: "image",
+        }),
+      );
     });
 
     expect(screen.queryByRole("button", { name: "Remove tag filter travel" })).not.toBeInTheDocument();
+
+    mocks.getCanonical.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: "video-1",
+            filename: "clip.mp4",
+            file_type: "video",
+            media_url: "/media/video-1",
+            poster_url: "/poster/video-1",
+            matched_tags: ["family"],
+            top_confidence_score: 0.88,
+            sort_tag_name: "family",
+          },
+        ],
+        total: 1,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
+    });
 
     fireEvent.click(screen.getByRole("radio", { name: "Videos" }));
 
     await waitFor(() => {
       expect(screen.queryByText("first.jpg")).not.toBeInTheDocument();
       expect(screen.getByText("clip.mp4")).toBeInTheDocument();
+      expect(screen.getByText("1 item · Page 1 of 1")).toBeInTheDocument();
+      expect(mocks.getCanonical).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          media_type: "video",
+        }),
+      );
+    });
+
+    mocks.getCanonical.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: "image-1",
+            filename: "first.jpg",
+            file_type: "image",
+            media_url: "/media/image-1",
+            poster_url: null,
+            matched_tags: ["travel"],
+            top_confidence_score: 0.94,
+            sort_tag_name: "travel",
+          },
+          {
+            id: "video-1",
+            filename: "clip.mp4",
+            file_type: "video",
+            media_url: "/media/video-1",
+            poster_url: "/poster/video-1",
+            matched_tags: ["family"],
+            top_confidence_score: 0.88,
+            sort_tag_name: "family",
+          },
+        ],
+        total: 2,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
     });
 
     fireEvent.click(screen.getByRole("radio", { name: "All" }));
@@ -148,6 +233,12 @@ describe("Gallery page", () => {
     await waitFor(() => {
       expect(screen.getByText("first.jpg")).toBeInTheDocument();
       expect(screen.getByText("clip.mp4")).toBeInTheDocument();
+      expect(screen.getByText("2 items · Page 1 of 1")).toBeInTheDocument();
+      expect(mocks.getCanonical).toHaveBeenLastCalledWith(
+        expect.not.objectContaining({
+          media_type: expect.anything(),
+        }),
+      );
     });
   });
 
@@ -155,6 +246,27 @@ describe("Gallery page", () => {
     renderPage();
 
     await screen.findByText("first.jpg");
+
+    mocks.getCanonical.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: "image-1",
+            filename: "first.jpg",
+            file_type: "image",
+            media_url: "/media/image-1",
+            poster_url: null,
+            matched_tags: ["travel"],
+            top_confidence_score: 0.94,
+            sort_tag_name: "travel",
+          },
+        ],
+        total: 1,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
+    });
 
     fireEvent.click(screen.getByRole("radio", { name: "Images" }));
 
@@ -165,6 +277,26 @@ describe("Gallery page", () => {
     });
 
     const input = screen.getByPlaceholderText("Filter gallery by tag");
+    mocks.getCanonical.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: "image-1",
+            filename: "first.jpg",
+            file_type: "image",
+            media_url: "/media/image-1",
+            poster_url: null,
+            matched_tags: ["travel"],
+            top_confidence_score: 0.94,
+            sort_tag_name: "travel",
+          },
+        ],
+        total: 1,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
+    });
     fireEvent.change(input, { target: { value: "travel" } });
     fireEvent.keyDown(input, { key: "Enter" });
 
@@ -173,6 +305,12 @@ describe("Gallery page", () => {
       expect(screen.getByText("1 tag filter · Images only applied")).toBeInTheDocument();
       expect(screen.getByText("first.jpg")).toBeInTheDocument();
       expect(screen.queryByText("clip.mp4")).not.toBeInTheDocument();
+      expect(mocks.getCanonical).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          media_type: "image",
+          tags: "travel",
+        }),
+      );
     });
   });
 
@@ -202,9 +340,9 @@ describe("Gallery page", () => {
           top_confidence_score: 0.9,
           sort_tag_name: null,
         })),
-        total_count: 20,
+        total: 20,
         page: 2,
-        limit: 10,
+        page_size: 10,
         total_pages: 2,
       },
     });
@@ -229,16 +367,16 @@ describe("Gallery page", () => {
     });
   });
 
-  it("updates status count to show filtered count when media type changes", async () => {
+  it("keeps status count aligned with server-filtered pagination", async () => {
     mocks.getCanonical.mockResolvedValue({
       data: {
         items: [
           { id: "v1", filename: "v1.jpg", file_type: "image", media_url: "/v1", poster_url: null, matched_tags: [], top_confidence_score: 0.9, sort_tag_name: null },
           { id: "v2", filename: "v2.mp4", file_type: "video", media_url: "/v2", poster_url: "/v2", matched_tags: [], top_confidence_score: 0.9, sort_tag_name: null },
         ],
-        total_count: 2,
+        total: 2,
         page: 1,
-        limit: 20,
+        page_size: 20,
         total_pages: 1,
       },
     });
@@ -247,16 +385,49 @@ describe("Gallery page", () => {
 
     await screen.findByText("2 items · Page 1 of 1");
 
+    mocks.getCanonical.mockResolvedValueOnce({
+      data: {
+        items: [{ id: "v1", filename: "v1.jpg", file_type: "image", media_url: "/v1", poster_url: null, matched_tags: [], top_confidence_score: 0.9, sort_tag_name: null }],
+        total: 3,
+        page: 1,
+        page_size: 20,
+        total_pages: 2,
+      },
+    });
+
     fireEvent.click(screen.getByRole("radio", { name: "Images" }));
 
     await waitFor(() => {
-      expect(screen.getByText("1 item · Page 1 of 1")).toBeInTheDocument();
+      expect(screen.getByText("3 items · Page 1 of 2")).toBeInTheDocument();
+    });
+
+    mocks.getCanonical.mockResolvedValueOnce({
+      data: {
+        items: [{ id: "v2", filename: "v2.mp4", file_type: "video", media_url: "/v2", poster_url: "/v2", matched_tags: [], top_confidence_score: 0.9, sort_tag_name: null }],
+        total: 1,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
     });
 
     fireEvent.click(screen.getByRole("radio", { name: "Videos" }));
 
     await waitFor(() => {
       expect(screen.getByText("1 item · Page 1 of 1")).toBeInTheDocument();
+    });
+
+    mocks.getCanonical.mockResolvedValueOnce({
+      data: {
+        items: [
+          { id: "v1", filename: "v1.jpg", file_type: "image", media_url: "/v1", poster_url: null, matched_tags: [], top_confidence_score: 0.9, sort_tag_name: null },
+          { id: "v2", filename: "v2.mp4", file_type: "video", media_url: "/v2", poster_url: "/v2", matched_tags: [], top_confidence_score: 0.9, sort_tag_name: null },
+        ],
+        total: 2,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
     });
 
     fireEvent.click(screen.getByRole("radio", { name: "All" }));

--- a/operator_console/main.py
+++ b/operator_console/main.py
@@ -321,6 +321,7 @@ class _DiscoveryQueryArgs:
     tags: tuple[str, ...]
     sort_by: str
     sort_order: str
+    file_type: str | None
     source: TagSource | None
     min_confidence: float | None
 
@@ -566,6 +567,7 @@ def _parse_discovery_query_args(
     tags: str | None,
     sort_by: str,
     sort_order: str | None,
+    media_type: str | None,
     source: str | None,
     min_confidence: float | None,
 ) -> _DiscoveryQueryArgs:
@@ -579,6 +581,13 @@ def _parse_discovery_query_args(
         normalized_sort_order = sort_order.strip().lower()
         if normalized_sort_order not in {"asc", "desc"}:
             raise HTTPException(status_code=400, detail="sort_order must be asc or desc.")
+
+    file_type: str | None = None
+    if media_type is not None:
+        normalized_media_type = media_type.strip().lower()
+        if normalized_media_type not in {"image", "video"}:
+            raise HTTPException(status_code=400, detail="media_type must be image or video.")
+        file_type = normalized_media_type
 
     source_value: TagSource | None = None
     if source is not None:
@@ -600,6 +609,7 @@ def _parse_discovery_query_args(
         tags=tag_items,
         sort_by=normalized_sort_by,
         sort_order=normalized_sort_order,
+        file_type=file_type,
         source=source_value,
         min_confidence=min_confidence,
     )
@@ -849,6 +859,7 @@ def create_app() -> FastAPI:
         tags: str | None = Query(default=None),
         sort_by: str = Query(default="created_at"),
         sort_order: str | None = Query(default=None),
+        media_type: str | None = Query(default=None),
         source: str | None = Query(default=None),
         min_confidence: float | None = Query(default=None),
         services: ReadServices = Depends(get_read_services),
@@ -859,6 +870,7 @@ def create_app() -> FastAPI:
             tags=tags,
             sort_by=sort_by,
             sort_order=sort_order,
+            media_type=media_type,
             source=source,
             min_confidence=min_confidence,
         )
@@ -870,6 +882,7 @@ def create_app() -> FastAPI:
                 tags=parsed.tags,
                 sort_by=parsed.sort_by,
                 sort_order=parsed.sort_order,
+                file_type=parsed.file_type,
                 source=parsed.source.value if parsed.source is not None else None,
                 min_confidence=parsed.min_confidence,
             ),

--- a/operator_console/tests/test_main.py
+++ b/operator_console/tests/test_main.py
@@ -2469,6 +2469,20 @@ def test_api_canonical_accepts_discovery_query_params() -> None:
     assert payload["items"][0]["matched_tags"] == ["city", "travel"]
 
 
+def test_api_canonical_accepts_media_type_filter() -> None:
+    fake = _FakeReadServices()
+    app.dependency_overrides[get_read_services] = lambda: fake
+    client = TestClient(app)
+    try:
+        response = client.get("/api/canonical?media_type=image")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert fake.last_gallery_call is not None
+    assert fake.last_gallery_call["file_type"] == "image"
+
+
 def test_api_canonical_applies_default_sort_order_for_tag_name() -> None:
     fake = _FakeReadServices()
     app.dependency_overrides[get_read_services] = lambda: fake
@@ -2508,6 +2522,18 @@ def test_api_canonical_rejects_invalid_source_and_confidence() -> None:
     assert "source" in bad_source.json()["errors"][0]["message"]
     assert bad_conf.status_code == 400
     assert "min_confidence" in bad_conf.json()["errors"][0]["message"]
+
+
+def test_api_canonical_rejects_invalid_media_type() -> None:
+    app.dependency_overrides[get_read_services] = _FakeReadServices
+    client = TestClient(app)
+    try:
+        response = client.get("/api/canonical?media_type=audio")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert "media_type" in response.json()["errors"][0]["message"]
 
 
 def test_api_canonical_tags_returns_suggestions() -> None:


### PR DESCRIPTION
## Summary
Fixes a correctness issue where the Library page applied media-type filtering on the client after fetching a paginated server response.

This caused divergence between:
- rendered items
- counts / status
- pagination metadata

## What changed
- backend canonical query now supports media-type filtering before pagination
- pagination metadata is derived from the filtered dataset
- frontend passes media type through canonical query requests
- Library page no longer relies on client-side page-slice filtering that diverges from server truth
- pagination resets to page 1 when filter changes

## Scope
Strictly limited to:
- media-type filtering correctness
- pagination alignment

No:
- Library redesign
- sorting or layout changes
- integrity or duplicate workflow changes
- broader canonical query refactors

## Validation
- verified filtered pagination for All / Images / Videos
- confirmed rendered items and pagination metadata reflect the same dataset
- updated targeted tests only for this corrected behavior

## Related
- #94
- #11
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
