### PR TITLE
feat(gui): add library-to-integrity routing for flagged items

### DIFF
--- a/media_manager/app/persistence/operator_console.py
+++ b/media_manager/app/persistence/operator_console.py
@@ -1599,13 +1599,13 @@ class OperatorConsoleReadService:
             with self._session_factory() as session:
                 integrity_rows = session.execute(
                     select(IntegrityCheck.file_instance_id, IntegrityCheck.status).where(
-                        IntegrityCheck.file_instance_id.in_(canonical_ids)
+                        IntegrityCheck.file_instance_id.in_(canonical_ids),
+                        IntegrityCheck.status.in_(("BROKEN", "SUSPECT")),
                     )
                 ).all()
             integrity_status_by_instance = {
                 file_instance_id: status
                 for file_instance_id, status in integrity_rows
-                if status in {"BROKEN", "SUSPECT"}
             }
         items = tuple(
             CanonicalGalleryItem(

--- a/media_manager/app/persistence/operator_console.py
+++ b/media_manager/app/persistence/operator_console.py
@@ -629,6 +629,7 @@ class CanonicalGalleryItem:
     matched_tags: tuple[str, ...] = ()
     top_confidence_score: float | None = None
     sort_tag_name: str | None = None
+    integrity_status: str | None = None
 
     def to_dict(self) -> dict[str, str | list[str] | float | None]:
         """Return a JSON-serializable mapping."""
@@ -641,6 +642,7 @@ class CanonicalGalleryItem:
             "matched_tags": list(self.matched_tags),
             "top_confidence_score": self.top_confidence_score,
             "sort_tag_name": self.sort_tag_name,
+            "integrity_status": self.integrity_status,
         }
 
 
@@ -1591,6 +1593,20 @@ class OperatorConsoleReadService:
             min_confidence=min_confidence,
         )
         page_rows = self._discovery_query.query(query)
+        canonical_ids = [UUID(item.id) for item in page_rows.items]
+        integrity_status_by_instance: dict[UUID, str] = {}
+        if canonical_ids:
+            with self._session_factory() as session:
+                integrity_rows = session.execute(
+                    select(IntegrityCheck.file_instance_id, IntegrityCheck.status).where(
+                        IntegrityCheck.file_instance_id.in_(canonical_ids)
+                    )
+                ).all()
+            integrity_status_by_instance = {
+                file_instance_id: status
+                for file_instance_id, status in integrity_rows
+                if status in {"BROKEN", "SUSPECT"}
+            }
         items = tuple(
             CanonicalGalleryItem(
                 id=item.id,
@@ -1601,6 +1617,7 @@ class OperatorConsoleReadService:
                 matched_tags=item.matched_tags,
                 top_confidence_score=item.top_confidence_score,
                 sort_tag_name=item.sort_tag_name,
+                integrity_status=integrity_status_by_instance.get(UUID(item.id)),
             )
             for item in page_rows.items
         )

--- a/media_manager/tests/test_operator_console_canonical_gallery.py
+++ b/media_manager/tests/test_operator_console_canonical_gallery.py
@@ -512,17 +512,22 @@ def test_get_canonical_gallery_surfaces_existing_integrity_problem_statuses(sess
     base = datetime(2026, 3, 2, 13, 50, tzinfo=UTC)
     content_a = UUID("65000000-0000-0000-0000-00000000000c")
     content_b = UUID("65000000-0000-0000-0000-00000000000d")
+    content_c = UUID("65000000-0000-0000-0000-00000000000e")
     broken_id = UUID("66000000-0000-0000-0000-00000000000c")
     healthy_id = UUID("66000000-0000-0000-0000-00000000000d")
+    suspect_id = UUID("66000000-0000-0000-0000-00000000000e")
     broken_run_id = UUID("67000000-0000-0000-0000-00000000000c")
     healthy_run_id = UUID("67000000-0000-0000-0000-00000000000d")
+    suspect_run_id = UUID("67000000-0000-0000-0000-00000000000e")
 
     with session_factory.begin() as session:
         _add_content(session, content_a, "hash-problem", base)
         _add_content(session, content_b, "hash-ok", base + timedelta(seconds=1))
+        _add_content(session, content_c, "hash-suspect", base + timedelta(seconds=2))
         session.flush()
         _add_instance(session, file_instance_id=broken_id, content_id=content_a, absolute_path="/gallery/problem.mp4", first_seen_at=base)
         _add_instance(session, file_instance_id=healthy_id, content_id=content_b, absolute_path="/gallery/ok.jpg", first_seen_at=base)
+        _add_instance(session, file_instance_id=suspect_id, content_id=content_c, absolute_path="/gallery/suspect.mov", first_seen_at=base)
         _add_assignment(
             session,
             assignment_id=UUID("68000000-0000-0000-0000-00000000000c"),
@@ -536,6 +541,13 @@ def test_get_canonical_gallery_surfaces_existing_integrity_problem_statuses(sess
             content_id=content_b,
             canonical_instance_id=healthy_id,
             assigned_at=base + timedelta(seconds=1),
+        )
+        _add_assignment(
+            session,
+            assignment_id=UUID("68000000-0000-0000-0000-00000000000e"),
+            content_id=content_c,
+            canonical_instance_id=suspect_id,
+            assigned_at=base + timedelta(seconds=2),
         )
         session.add_all(
             [
@@ -559,6 +571,16 @@ def test_get_canonical_gallery_surfaces_existing_integrity_problem_statuses(sess
                     started_at=base + timedelta(seconds=2),
                     completed_at=base + timedelta(seconds=3),
                 ),
+                IntegrityCheckRun(
+                    id=suspect_run_id,
+                    scan_mode="FAST",
+                    status="COMPLETED",
+                    paths=["/gallery/suspect.mov"],
+                    scanned_count=1,
+                    issues_found=1,
+                    started_at=base + timedelta(seconds=4),
+                    completed_at=base + timedelta(seconds=5),
+                ),
                 IntegrityCheck(
                     file_instance_id=broken_id,
                     latest_run_id=broken_run_id,
@@ -577,6 +599,15 @@ def test_get_canonical_gallery_surfaces_existing_integrity_problem_statuses(sess
                     last_checked_at=base + timedelta(seconds=3),
                     last_scanned_absolute_path="/gallery/ok.jpg",
                 ),
+                IntegrityCheck(
+                    file_instance_id=suspect_id,
+                    latest_run_id=suspect_run_id,
+                    status="SUSPECT",
+                    confidence=0.61,
+                    readability_ok=False,
+                    last_checked_at=base + timedelta(seconds=5),
+                    last_scanned_absolute_path="/gallery/suspect.mov",
+                ),
             ]
         )
 
@@ -585,6 +616,7 @@ def test_get_canonical_gallery_surfaces_existing_integrity_problem_statuses(sess
     by_id = {item.id: item for item in page.items}
     assert by_id[str(broken_id)].integrity_status == "BROKEN"
     assert by_id[str(healthy_id)].integrity_status is None
+    assert by_id[str(suspect_id)].integrity_status == "SUSPECT"
 
 
 def test_resolve_media_source_returns_media_for_active_image_and_video(session_factory, tmp_path: Path) -> None:

--- a/media_manager/tests/test_operator_console_canonical_gallery.py
+++ b/media_manager/tests/test_operator_console_canonical_gallery.py
@@ -13,6 +13,8 @@ from media_manager.app.persistence.models import (
     FileContent,
     FileInstance,
     FileInstanceStatus,
+    IntegrityCheck,
+    IntegrityCheckRun,
     Tag,
     TagSource,
 )
@@ -503,6 +505,86 @@ def test_get_canonical_gallery_created_at_tie_breaks_by_content_id(session_facto
 
     assert [item.id for item in first.items[:2]] == [str(a_id), str(b_id)]
     assert [item.id for item in second.items[:2]] == [str(a_id), str(b_id)]
+
+
+def test_get_canonical_gallery_surfaces_existing_integrity_problem_statuses(session_factory) -> None:
+    service = OperatorConsoleReadService(session_factory)
+    base = datetime(2026, 3, 2, 13, 50, tzinfo=UTC)
+    content_a = UUID("65000000-0000-0000-0000-00000000000c")
+    content_b = UUID("65000000-0000-0000-0000-00000000000d")
+    broken_id = UUID("66000000-0000-0000-0000-00000000000c")
+    healthy_id = UUID("66000000-0000-0000-0000-00000000000d")
+    broken_run_id = UUID("67000000-0000-0000-0000-00000000000c")
+    healthy_run_id = UUID("67000000-0000-0000-0000-00000000000d")
+
+    with session_factory.begin() as session:
+        _add_content(session, content_a, "hash-problem", base)
+        _add_content(session, content_b, "hash-ok", base + timedelta(seconds=1))
+        session.flush()
+        _add_instance(session, file_instance_id=broken_id, content_id=content_a, absolute_path="/gallery/problem.mp4", first_seen_at=base)
+        _add_instance(session, file_instance_id=healthy_id, content_id=content_b, absolute_path="/gallery/ok.jpg", first_seen_at=base)
+        _add_assignment(
+            session,
+            assignment_id=UUID("68000000-0000-0000-0000-00000000000c"),
+            content_id=content_a,
+            canonical_instance_id=broken_id,
+            assigned_at=base,
+        )
+        _add_assignment(
+            session,
+            assignment_id=UUID("68000000-0000-0000-0000-00000000000d"),
+            content_id=content_b,
+            canonical_instance_id=healthy_id,
+            assigned_at=base + timedelta(seconds=1),
+        )
+        session.add_all(
+            [
+                IntegrityCheckRun(
+                    id=broken_run_id,
+                    scan_mode="FAST",
+                    status="COMPLETED",
+                    paths=["/gallery/problem.mp4"],
+                    scanned_count=1,
+                    issues_found=1,
+                    started_at=base,
+                    completed_at=base + timedelta(seconds=1),
+                ),
+                IntegrityCheckRun(
+                    id=healthy_run_id,
+                    scan_mode="FAST",
+                    status="COMPLETED",
+                    paths=["/gallery/ok.jpg"],
+                    scanned_count=1,
+                    issues_found=0,
+                    started_at=base + timedelta(seconds=2),
+                    completed_at=base + timedelta(seconds=3),
+                ),
+                IntegrityCheck(
+                    file_instance_id=broken_id,
+                    latest_run_id=broken_run_id,
+                    status="BROKEN",
+                    confidence=0.97,
+                    readability_ok=False,
+                    last_checked_at=base + timedelta(seconds=1),
+                    last_scanned_absolute_path="/gallery/problem.mp4",
+                ),
+                IntegrityCheck(
+                    file_instance_id=healthy_id,
+                    latest_run_id=healthy_run_id,
+                    status="OK",
+                    confidence=0.02,
+                    readability_ok=True,
+                    last_checked_at=base + timedelta(seconds=3),
+                    last_scanned_absolute_path="/gallery/ok.jpg",
+                ),
+            ]
+        )
+
+    page = service.get_canonical_gallery()
+
+    by_id = {item.id: item for item in page.items}
+    assert by_id[str(broken_id)].integrity_status == "BROKEN"
+    assert by_id[str(healthy_id)].integrity_status is None
 
 
 def test_resolve_media_source_returns_media_for_active_image_and_video(session_factory, tmp_path: Path) -> None:

--- a/operator_console/gui_app/src/components/media/MediaCard.tsx
+++ b/operator_console/gui_app/src/components/media/MediaCard.tsx
@@ -29,7 +29,8 @@ export function MediaCard({ file, onPreview, detailHref, integrityHref, density 
   const compactActions = density === "small" || density === "compact";
   const hideSupplementaryMeta = density === "compact";
   const hideTagChip = density === "compact";
-  const showIntegrityAction = Boolean(integrityHref && (file.integrity_status === "BROKEN" || file.integrity_status === "SUSPECT"));
+  const showIntegrityAction = file.integrity_status === "BROKEN" || file.integrity_status === "SUSPECT";
+  const integrityTarget = integrityHref || "/integrity";
 
   useEffect(() => {
     setImageSrc(preferredPoster);
@@ -131,7 +132,7 @@ export function MediaCard({ file, onPreview, detailHref, integrityHref, density 
             ) : null}
             {showIntegrityAction ? (
               <Button asChild type="button" variant="outline" size="icon" className="h-8 w-8 shrink-0">
-                <Link to={integrityHref ?? "/integrity"} aria-label={`Review ${file.filename} in Integrity`} title="Review in Integrity">
+                <Link to={integrityTarget} aria-label={`Review ${file.filename} in Integrity`} title="Review in Integrity">
                   <ArrowUpRight className="h-4 w-4" />
                 </Link>
               </Button>
@@ -149,7 +150,7 @@ export function MediaCard({ file, onPreview, detailHref, integrityHref, density 
             ) : null}
             {showIntegrityAction ? (
               <Button asChild type="button" variant="outline" size="sm" className="w-full min-w-0">
-                <Link to={integrityHref ?? "/integrity"}>Review in Integrity</Link>
+                <Link to={integrityTarget}>Review in Integrity</Link>
               </Button>
             ) : null}
           </div>

--- a/operator_console/gui_app/src/components/media/MediaCard.tsx
+++ b/operator_console/gui_app/src/components/media/MediaCard.tsx
@@ -10,6 +10,7 @@ interface MediaCardProps {
   file: CanonicalFile;
   onPreview?: () => void;
   detailHref?: string;
+  integrityHref?: string;
   density?: "large" | "medium" | "small" | "compact";
 }
 
@@ -20,7 +21,7 @@ function primaryTagLabel(file: CanonicalFile): string | null {
   return score ? `${tag} ${score}` : tag;
 }
 
-export function MediaCard({ file, onPreview, detailHref, density = "medium" }: MediaCardProps) {
+export function MediaCard({ file, onPreview, detailHref, integrityHref, density = "medium" }: MediaCardProps) {
   const isVideo = file.file_type === "video";
   const tagLabel = primaryTagLabel(file);
   const preferredPoster = isVideo ? file.poster_url ?? null : file.media_url;
@@ -28,6 +29,7 @@ export function MediaCard({ file, onPreview, detailHref, density = "medium" }: M
   const compactActions = density === "small" || density === "compact";
   const hideSupplementaryMeta = density === "compact";
   const hideTagChip = density === "compact";
+  const showIntegrityAction = Boolean(integrityHref && (file.integrity_status === "BROKEN" || file.integrity_status === "SUSPECT"));
 
   useEffect(() => {
     setImageSrc(preferredPoster);
@@ -127,15 +129,27 @@ export function MediaCard({ file, onPreview, detailHref, density = "medium" }: M
                 </Link>
               </Button>
             ) : null}
+            {showIntegrityAction ? (
+              <Button asChild type="button" variant="outline" size="icon" className="h-8 w-8 shrink-0">
+                <Link to={integrityHref ?? "/integrity"} aria-label={`Review ${file.filename} in Integrity`} title="Review in Integrity">
+                  <ArrowUpRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            ) : null}
           </div>
         ) : (
-          <div className="grid gap-2 pt-1 sm:grid-cols-2">
+          <div className={cn("grid gap-2 pt-1", showIntegrityAction ? "sm:grid-cols-3" : "sm:grid-cols-2")}>
             <Button type="button" variant="outline" size="sm" className="w-full min-w-0" onClick={onPreview}>
               Quick preview
             </Button>
             {detailHref ? (
               <Button asChild type="button" size="sm" className="w-full min-w-0">
                 <Link to={detailHref}>View details</Link>
+              </Button>
+            ) : null}
+            {showIntegrityAction ? (
+              <Button asChild type="button" variant="outline" size="sm" className="w-full min-w-0">
+                <Link to={integrityHref ?? "/integrity"}>Review in Integrity</Link>
               </Button>
             ) : null}
           </div>

--- a/operator_console/gui_app/src/components/media/MediaGrid.tsx
+++ b/operator_console/gui_app/src/components/media/MediaGrid.tsx
@@ -11,6 +11,7 @@ interface MediaGridProps {
   emptyDescription?: string;
   onPreview?: (file: CanonicalFile) => void;
   getDetailHref?: (file: CanonicalFile) => string;
+  getIntegrityHref?: (file: CanonicalFile) => string | undefined;
   gridClassName?: string;
   skeletonCount?: number;
   density?: "large" | "medium" | "small" | "compact";
@@ -23,6 +24,7 @@ export function MediaGrid({
   emptyDescription = "Run an ingest to populate the gallery",
   onPreview,
   getDetailHref,
+  getIntegrityHref,
   gridClassName = "grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-5",
   skeletonCount = 10,
   density = "medium",
@@ -62,6 +64,7 @@ export function MediaGrid({
           file={file}
           onPreview={() => onPreview?.(file)}
           detailHref={getDetailHref?.(file)}
+          integrityHref={getIntegrityHref?.(file)}
           density={density}
         />
       ))}

--- a/operator_console/gui_app/src/lib/api/mappers/media.ts
+++ b/operator_console/gui_app/src/lib/api/mappers/media.ts
@@ -21,6 +21,7 @@ import type {
 export function mapCanonicalItems(items: unknown[]): CanonicalFile[] {
   return items.map((item) => {
     const row = item as Record<string, unknown>;
+    const integrityStatus = row.integrity_status ? String(row.integrity_status) : null;
     return {
       id: String(row.id ?? ""),
       filename: String(row.filename ?? ""),
@@ -31,6 +32,7 @@ export function mapCanonicalItems(items: unknown[]): CanonicalFile[] {
       top_confidence_score:
         typeof row.top_confidence_score === "number" ? row.top_confidence_score : null,
       sort_tag_name: row.sort_tag_name ? String(row.sort_tag_name) : null,
+      integrity_status: integrityStatus === "BROKEN" || integrityStatus === "SUSPECT" ? integrityStatus : null,
     };
   });
 }

--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -364,6 +364,9 @@ export default function GalleryPage() {
           }
           onPreview={setSelectedFile}
           getDetailHref={(file) => `/gallery/${file.id}`}
+          getIntegrityHref={(file) =>
+            file.integrity_status === "BROKEN" || file.integrity_status === "SUSPECT" ? "/integrity" : undefined
+          }
         />
 
         {data && totalPages > 1 && (

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -112,6 +112,49 @@ describe("Gallery page", () => {
     expect(screen.queryByRole("tab", { name: /integrity/i })).not.toBeInTheDocument();
   });
 
+  it("shows a per-row Review in Integrity action only for items already marked with an integrity problem", async () => {
+    mocks.getCanonical.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: "broken-1",
+            filename: "broken.mp4",
+            file_type: "video",
+            media_url: "/media/broken-1",
+            poster_url: "/poster/broken-1",
+            matched_tags: ["travel"],
+            top_confidence_score: 0.94,
+            sort_tag_name: "travel",
+            integrity_status: "BROKEN",
+          },
+          {
+            id: "healthy-1",
+            filename: "healthy.jpg",
+            file_type: "image",
+            media_url: "/media/healthy-1",
+            poster_url: null,
+            matched_tags: ["family"],
+            top_confidence_score: 0.88,
+            sort_tag_name: "family",
+            integrity_status: "OK",
+          },
+        ],
+        total: 2,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
+    });
+
+    renderPage();
+
+    const integrityLinks = await screen.findAllByRole("link", { name: "Review in Integrity" });
+    expect(integrityLinks).toHaveLength(1);
+    expect(integrityLinks[0]).toHaveAttribute("href", "/integrity");
+    expect(screen.getByText("broken.mp4")).toBeInTheDocument();
+    expect(screen.getByText("healthy.jpg")).toBeInTheDocument();
+  });
+
   it("keeps filter controls interactive inside the shell controls row", async () => {
     renderPage();
 

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -138,8 +138,19 @@ describe("Gallery page", () => {
             sort_tag_name: "family",
             integrity_status: "OK",
           },
+          {
+            id: "suspect-1",
+            filename: "suspect.mov",
+            file_type: "video",
+            media_url: "/media/suspect-1",
+            poster_url: "/poster/suspect-1",
+            matched_tags: ["pets"],
+            top_confidence_score: 0.72,
+            sort_tag_name: "pets",
+            integrity_status: "SUSPECT",
+          },
         ],
-        total: 2,
+        total: 3,
         page: 1,
         page_size: 20,
         total_pages: 1,
@@ -149,10 +160,12 @@ describe("Gallery page", () => {
     renderPage();
 
     const integrityLinks = await screen.findAllByRole("link", { name: "Review in Integrity" });
-    expect(integrityLinks).toHaveLength(1);
+    expect(integrityLinks).toHaveLength(2);
     expect(integrityLinks[0]).toHaveAttribute("href", "/integrity");
+    expect(integrityLinks[1]).toHaveAttribute("href", "/integrity");
     expect(screen.getByText("broken.mp4")).toBeInTheDocument();
     expect(screen.getByText("healthy.jpg")).toBeInTheDocument();
+    expect(screen.getByText("suspect.mov")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Review healthy.jpg in Integrity" })).not.toBeInTheDocument();
   });
 

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -153,6 +153,7 @@ describe("Gallery page", () => {
     expect(integrityLinks[0]).toHaveAttribute("href", "/integrity");
     expect(screen.getByText("broken.mp4")).toBeInTheDocument();
     expect(screen.getByText("healthy.jpg")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Review healthy.jpg in Integrity" })).not.toBeInTheDocument();
   });
 
   it("keeps filter controls interactive inside the shell controls row", async () => {

--- a/operator_console/gui_app/src/types/media.ts
+++ b/operator_console/gui_app/src/types/media.ts
@@ -7,6 +7,7 @@ export interface CanonicalFile {
   matched_tags: string[];
   top_confidence_score: number | null;
   sort_tag_name?: string | null;
+  integrity_status?: "SUSPECT" | "BROKEN" | null;
 }
 
 export interface CanonicalFileDetail {


### PR DESCRIPTION
## Summary
- add a per-row `Review in Integrity` action in Library results for items already carrying an existing integrity-problem status
- route those items to the existing Integrity Checks page
- keep the slice limited to Library-to-Integrity routing only

## What changed
- surface existing flagged integrity status in the gallery read model only for flagged items
- show `Review in Integrity` only for `BROKEN` / `SUSPECT` items
- keep healthy items unchanged
- add focused backend and GUI test coverage

## What did not change
- no Library browsing default changes
- no filtering or exclusion policy changes
- no Duplicate Review changes
- no Integrity workflow redesign
- no new integrity classification logic

## Validation
- `./.venv/bin/python -m pytest media_manager/tests/test_operator_console_canonical_gallery.py -q`
- `npm test -- --run src/test/gallery-page.test.tsx`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
