### PR TITLE
fix(gui): stop showing stale library page items during pagination

### DIFF
--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
 import { ErrorAlert } from "@/components/ErrorAlert";
 import { PageShell } from "@/components/layout/PageShell";
@@ -124,18 +124,6 @@ export default function GalleryPage() {
     }),
     [densityPreset.limit, mediaTypeFilter, page, sortBy, sortOrder, tagsParam],
   );
-  const previousCanonicalParamsRef = useRef(canonicalParams);
-  const keepPreviousCanonicalPageData =
-    previousCanonicalParamsRef.current.page !== canonicalParams.page &&
-    previousCanonicalParamsRef.current.limit === canonicalParams.limit &&
-    previousCanonicalParamsRef.current.tags === canonicalParams.tags &&
-    previousCanonicalParamsRef.current.sort_by === canonicalParams.sort_by &&
-    previousCanonicalParamsRef.current.sort_order === canonicalParams.sort_order &&
-    previousCanonicalParamsRef.current.media_type === canonicalParams.media_type;
-
-  useEffect(() => {
-    previousCanonicalParamsRef.current = canonicalParams;
-  }, [canonicalParams]);
 
   const tagsQuery = useQuery({
     queryKey: queryKeys.canonicalTags(""),
@@ -147,7 +135,6 @@ export default function GalleryPage() {
     queryKey: queryKeys.canonical(canonicalParams),
     queryFn: async () => (await getCanonical(canonicalParams)).data,
     staleTime: queryOptions.canonical.staleTime,
-    placeholderData: keepPreviousCanonicalPageData ? keepPreviousData : undefined,
   });
 
   const data = (galleryQuery.data as PaginatedResponse<CanonicalFile> | undefined) ?? null;

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -550,4 +550,92 @@ describe("Gallery page", () => {
       expect(screen.getByText("2 items · Page 1 of 1")).toBeInTheDocument();
     });
   });
+
+  it("does not show previous page items while the next page is loading", async () => {
+    mocks.getCanonical
+      .mockResolvedValueOnce({
+        data: {
+          items: [
+            {
+              id: "page-1-image",
+              filename: "page-1-image.jpg",
+              file_type: "image",
+              media_url: "/media/page-1-image",
+              poster_url: null,
+              matched_tags: [],
+              top_confidence_score: 0.91,
+              sort_tag_name: null,
+            },
+            {
+              id: "page-1-video",
+              filename: "page-1-video.mp4",
+              file_type: "video",
+              media_url: "/media/page-1-video",
+              poster_url: "/poster/page-1-video",
+              matched_tags: [],
+              top_confidence_score: 0.88,
+              sort_tag_name: null,
+            },
+          ],
+          total: 40,
+          page: 1,
+          page_size: 20,
+          total_pages: 2,
+        },
+      });
+
+    let resolvePageTwo: ((value: unknown) => void) | null = null;
+    mocks.getCanonical.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePageTwo = resolve;
+        }),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText("page-1-image.jpg")).toBeInTheDocument();
+    expect(screen.getByText("page-1-video.mp4")).toBeInTheDocument();
+    expect(screen.getByText("40 items · Page 1 of 2")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("link", { name: "Go to next page" }));
+
+    await waitFor(() => {
+      expect(mocks.getCanonical).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page: 2,
+        }),
+      );
+      expect(screen.getByText("Loading gallery...")).toBeInTheDocument();
+      expect(screen.queryByText("page-1-image.jpg")).not.toBeInTheDocument();
+      expect(screen.queryByText("page-1-video.mp4")).not.toBeInTheDocument();
+    });
+
+    resolvePageTwo?.({
+      data: {
+        items: [
+          {
+            id: "page-2-image",
+            filename: "page-2-image.jpg",
+            file_type: "image",
+            media_url: "/media/page-2-image",
+            poster_url: null,
+            matched_tags: [],
+            top_confidence_score: 0.82,
+            sort_tag_name: null,
+          },
+        ],
+        total: 40,
+        page: 2,
+        page_size: 20,
+        total_pages: 2,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("40 items · Page 2 of 2")).toBeInTheDocument();
+      expect(screen.getByText("page-2-image.jpg")).toBeInTheDocument();
+      expect(screen.queryByText("page-1-image.jpg")).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Fix Library stale UI during pagination.

The Library page previously updated page/status state immediately during page navigation while retaining and rendering the previous page's items until the next response arrived. This created a temporary mismatch where the screen said page N+1 but still showed page N results.

This change removes previous-page placeholder retention for the canonical Library query so grid content remains consistent with the active page state.

## Scope
- operator_console/gui_app/src/pages/GalleryPage.tsx
- operator_console/gui_app/src/test/gallery-page.test.tsx

## Validation
- Added frontend regression coverage for delayed next-page response during pagination
- npm test -- --run src/test/gallery-page.test.tsx
- Result: 11 passed

## Out of scope
- backend/API changes
- media-type filter plumbing
- query-key redesign
- broader pagination redesign

## Issue
Closes #93
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
