### PR TITLE
docs(policy): define repo-grounded usable-default Library policy

### DIFF
--- a/documentation/architecture/index.md
+++ b/documentation/architecture/index.md
@@ -13,3 +13,4 @@ This section documents the operating model and runtime invariants for media-mana
 - [State Machine](../STATE_MACHINE.md)
 - [Architecture Guardrails](../ARCHITECTURE_GUARDRAILS.md)
 - [Library readiness restart handoff (2026-04-03)](library-readiness-restart-handoff-2026-04-03.md)
+- [Library Usable-Default Policy](library-usable-default-policy.md)

--- a/documentation/architecture/library-usable-default-policy.md
+++ b/documentation/architecture/library-usable-default-policy.md
@@ -20,7 +20,7 @@ This document defines usable-default Library browsing only in terms of the curre
 
 | Current Gallery state | Included in default Library | Reason |
 |---|---|---|
-| Active canonical image/video item with `integrity_status = null` | Yes | This is the current healthy/default-visible state exposed by the Gallery model. `OK` is not separately surfaced to the Library; it collapses to `null`. |
+| Active canonical image/video item with `integrity_status = null` | Yes | This is the current healthy/default-visible state exposed by the Gallery model. `OK` can exist in `IntegrityCheck.status` storage, but the Gallery query only finds `BROKEN`/`SUSPECT` rows, so healthy items return `null`. |
 | Active canonical image/video item with `integrity_status = BROKEN` | No | This is an explicit integrity-problem state already exposed in Gallery and already associated with Integrity workflow routing. |
 | Active canonical image/video item with `integrity_status = SUSPECT` | No | This is an explicit warning/problem state already exposed in Gallery and already associated with Integrity workflow routing. |
 

--- a/documentation/architecture/library-usable-default-policy.md
+++ b/documentation/architecture/library-usable-default-policy.md
@@ -1,0 +1,37 @@
+# Library Usable-Default Policy
+
+## Purpose
+
+This document defines usable-default Library browsing only in terms of the current Gallery state model already exposed in this repo. It is the source of truth for follow-on work in #111, #112, #113, and #114.
+
+## Current Gallery State Model
+
+- The Gallery frontend consumes `CanonicalFile.integrity_status?: "SUSPECT" | "BROKEN" | null` and no other Library-facing health field (`operator_console/gui_app/src/types/media.ts:1-11`).
+- The canonical gallery backend only attaches `integrity_status` when the latest integrity row is `BROKEN` or `SUSPECT`; items with `OK` are surfaced as `integrity_status = null` (`media_manager/app/persistence/operator_console.py:1595-1623`).
+- The default gallery dataset currently includes only active canonical items whose paths resolve to `image` or `video` (`media_manager/app/persistence/discovery_query.py:208-259`).
+- The existing backend test proves the current Library-facing state surface is:
+  - healthy item -> `integrity_status = null`
+  - broken item -> `integrity_status = BROKEN`
+  - suspect item -> `integrity_status = SUSPECT`
+  (`media_manager/tests/test_operator_console_canonical_gallery.py:510-619`).
+- The current Library UI text claims usable-default exclusion, and the current Integrity route is shown only for `BROKEN` / `SUSPECT` items (`operator_console/gui_app/src/pages/GalleryPage.tsx:326-356`).
+
+## Policy Table
+
+| Current Gallery state | Included in default Library | Reason |
+|---|---|---|
+| Active canonical image/video item with `integrity_status = null` | Yes | This is the current healthy/default-visible state exposed by the Gallery model. `OK` is not separately surfaced to the Library; it collapses to `null`. |
+| Active canonical image/video item with `integrity_status = BROKEN` | No | This is an explicit integrity-problem state already exposed in Gallery and already associated with Integrity workflow routing. |
+| Active canonical image/video item with `integrity_status = SUSPECT` | No | This is an explicit warning/problem state already exposed in Gallery and already associated with Integrity workflow routing. |
+
+## Term Mapping
+
+- `unplayable`: not separately represented in current Gallery state. The current repo only exposes `BROKEN` / `SUSPECT` as Library-facing integrity problem states. If product language continues using `unplayable`, follow-on work should either map it explicitly to one of those states or mark it as broader than the current Gallery model.
+- `unreadable`: indirectly present in integrity persistence via `readability_ok`, but not exposed in the current Gallery payload or query inputs (`media_manager/tests/test_operator_console_canonical_gallery.py:584-609`). It is therefore not currently a direct Library policy input.
+- `unknown`: not a current Gallery state. `UNKNOWN` exists in duplicate recommendation types, not in `CanonicalFile` or the canonical gallery response (`operator_console/gui_app/src/types/media.ts:53-100`).
+- `unscanned`: not a current Gallery state. The Gallery payload does not expose scan presence/absence as a separate field.
+
+## Implementation Notes
+
+- Follow-on backend work should implement usable-default exclusion using only the current Gallery-facing states above unless a later issue deliberately expands the state model.
+- Follow-on UI messaging must not claim support for `unplayable`, `unreadable`, `unknown`, or `unscanned` as separate Library rules unless those concepts are first made explicit in Gallery data.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Integrity Review and Reclaim Rollout: architecture/integrity-reclaim-rollout.md
       - Organize Media UX Feedback: architecture/pipeline-wizard-ux-feedback-2026-03-15.md
       - Library readiness restart handoff (2026-04-03): architecture/library-readiness-restart-handoff-2026-04-03.md
+      - Library Usable-Default Policy: architecture/library-usable-default-policy.md
       - ADR:
           - ADR Index: architecture/adr/index.md
           - ADR-0001 Runtime Invariants: architecture/adr/0001-runtime-invariants-hard-constraints.md


### PR DESCRIPTION
## Summary


Adds a repo-grounded usable-default Library policy document at:


- `documentation/architecture/library-usable-default-policy.md`


This PR is intentionally documentation-only. It does not change backend queries, UI behavior, schema/state fields, or Integrity workflows.


## What changed


### Policy artifact
- defines usable-default Library inclusion/exclusion using only current Gallery-relevant repo concepts
- includes an explicit state table for:
  - `integrity_status = null`
  - `integrity_status = BROKEN`
  - `integrity_status = SUSPECT`
- explicitly calls out unresolved terms rather than inventing new policy state:
  - `unplayable`
  - `unreadable`
  - `unknown`
  - `unscanned`


### Scope protection
Did not change:
- backend queries
- UI copy
- schema or state fields
- Integrity workflows
- Gallery behavior
- tests


## Why this PR is intentionally narrow


Issue #110 was tightened into a documentation/spec slice so the usable-default Library policy is grounded in the repo's actual current state model before implementation proceeds.


This document is intended to be the policy anchor for follow-on issues:
- #111 backend exclusion
- #112 truthful messaging
- #113 Gallery UI/test alignment
- #114 Library vs Integrity separation


## Related


- #110
- #11
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
