### PR TITLE
fix(gui): make Gallery header copy truthful to usable-default policy

### DIFF
--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -327,7 +327,7 @@ export default function GalleryPage() {
     <PageShell
       variant="browse-list"
       title="Library"
-      description="Library shows usable media by default. Broken, unplayable, and integrity-failed items are excluded from default browsing. Use filters, sorting, preview, and the detail view to quickly find the photo or video you need."
+      description="Library shows usable media by default. Items marked BROKEN or SUSPECT are excluded from default browsing. Use filters, sorting, preview, and the detail view to quickly find the photo or video you need."
       controls={controls}
     >
       {galleryQuery.error ? (

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -104,9 +104,7 @@ describe("Gallery page", () => {
     renderPage();
 
     expect(await screen.findByText(/Library shows usable media by default\./)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Broken, unplayable, and integrity-failed items are excluded from default browsing\./),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Items marked BROKEN or SUSPECT are excluded from default browsing\./)).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /integrity/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /integrity/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: /integrity/i })).not.toBeInTheDocument();


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
