### PR TITLE
feat(gui): align IntegrityPage with shared page shell

### DIFF
--- a/operator_console/gui_app/src/pages/IntegrityPage.tsx
+++ b/operator_console/gui_app/src/pages/IntegrityPage.tsx
@@ -4,7 +4,7 @@ import { AlertTriangle, Loader2, ShieldCheck, ShieldOff } from "lucide-react";
 
 import { LiveProgressPanel } from "@/components/progress/LiveProgressPanel";
 import { ErrorAlert } from "@/components/ErrorAlert";
-import { TopSurfaceHeader } from "@/components/layout/TopSurfaceHeader";
+import { PageShell } from "@/components/layout/PageShell";
 import { StatusBadge } from "@/components/StatusBadge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -303,14 +303,10 @@ export default function IntegrityPage() {
           ]
         : [];
 
-  return (
-    <div className="space-y-6 p-6">
-      <TopSurfaceHeader
-        badge="Integrity"
-        title="Integrity Checks"
-        description="Read-only scan results for playback and file-health issues."
-      >
-        <div className="flex flex-col items-end gap-2">
+  const controls = (
+    <div className="rounded-[28px] border border-border/70 bg-card/70 p-4 shadow-sm backdrop-blur">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
           {policy ? (
             <p className="text-xs text-muted-foreground">
               Saved default scan mode: {policy.integrity.default_scan_mode === "DEEP" ? "Deep" : "Quick"}
@@ -322,7 +318,9 @@ export default function IntegrityPage() {
             <p>By default, unchanged files are skipped.</p>
             <p>Full rescan checks everything again.</p>
           </div>
-          <div className="flex gap-2">
+        </div>
+        <div className="flex flex-col items-start gap-3 lg:items-end">
+          <div className="flex flex-wrap gap-2">
             <Button
               variant="outline"
               onClick={() => scanMutation.mutate({ mode: "FAST", fullRescan })}
@@ -348,7 +346,18 @@ export default function IntegrityPage() {
             </Label>
           </div>
         </div>
-      </TopSurfaceHeader>
+      </div>
+    </div>
+  );
+
+  return (
+    <PageShell
+      variant="standard-admin"
+      title="Integrity Checks"
+      description="Read-only scan results for playback and file-health issues."
+      controls={controls}
+    >
+      <div data-page-primary-surface className="-mt-1 space-y-6">
 
       <Card>
         <CardHeader className="space-y-3">
@@ -662,6 +671,7 @@ export default function IntegrityPage() {
           </CardContent>
         </Card>
       </div>
-    </div>
+      </div>
+    </PageShell>
   );
 }

--- a/operator_console/gui_app/src/test/integrity-page.test.tsx
+++ b/operator_console/gui_app/src/test/integrity-page.test.tsx
@@ -156,6 +156,9 @@ describe("IntegrityPage", () => {
     renderPage();
 
     expect(await screen.findByText("Integrity Checks")).toBeInTheDocument();
+    expect(document.querySelector('[data-page-shell="standard-admin"]')).toBeTruthy();
+    expect(document.querySelector("[data-page-shell-controls]")).toBeTruthy();
+    expect(document.querySelector("[data-page-primary-surface]")).toBeTruthy();
     expect(screen.getByText("Integrity Scan Status")).toBeInTheDocument();
     expect(
       screen.getByText("Start a Quick Scan or Deep Scan above. Live activity and the latest scan summary will appear here."),


### PR DESCRIPTION
## Summary

Aligns \`IntegrityPage\` with the current shared page-shell, control hierarchy, and spacing standards.

This PR is intentionally limited to page-structural conformance only. It does not redesign the Integrity workflow or change backend/API behavior.

## What changed

### Shared page-shell adoption
- replaced the bespoke top-level page wrapper with \`PageShell\`
- used:
  - \`variant="standard-admin"\`
- preserved the existing Integrity page title and description

### Controls surface
- moved the existing scan controls / guidance into the shared shell \`controls\` area
- preserved:
  - saved default scan mode text
  - scan guidance copy
  - Quick / Deep scan buttons
  - Full rescan toggle

### Main work area
- wrapped the main work area with:
  - \`data-page-primary-surface\`
- aligned the page structure with the newer operator-page shell pattern

### Tests
Updated:
- \`operator_console/gui_app/src/test/integrity-page.test.tsx\`

Verified:
- page renders with \`data-page-shell="standard-admin"\`
- page renders shell controls
- page renders \`data-page-primary-surface\`

## Scope protection
Did not change:
- Integrity workflow behavior
- scan logic
- queue/detail behavior
- routing
- query behavior
- backend/API behavior
- any other pages (\`AdminPage\`, \`OperationsPage\`, \`MediaDetailPage\`, \`DuplicatesPage\`)

## Validation

Frontend test command:
cd operator_console/gui_app && npm run test -- src/test/integrity-page.test.tsx

Result:
- 9 passed

## Related

- #90
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
