### PR TITLE
chore(backend): remove dead gallery integrity lookup

### DIFF
--- a/media_manager/app/persistence/operator_console.py
+++ b/media_manager/app/persistence/operator_console.py
@@ -1593,20 +1593,6 @@ class OperatorConsoleReadService:
             min_confidence=min_confidence,
         )
         page_rows = self._discovery_query.query(query)
-        canonical_ids = [UUID(item.id) for item in page_rows.items]
-        integrity_status_by_instance: dict[UUID, str] = {}
-        if canonical_ids:
-            with self._session_factory() as session:
-                integrity_rows = session.execute(
-                    select(IntegrityCheck.file_instance_id, IntegrityCheck.status).where(
-                        IntegrityCheck.file_instance_id.in_(canonical_ids),
-                        IntegrityCheck.status.in_(("BROKEN", "SUSPECT")),
-                    )
-                ).all()
-            integrity_status_by_instance = {
-                file_instance_id: status
-                for file_instance_id, status in integrity_rows
-            }
         items = tuple(
             CanonicalGalleryItem(
                 id=item.id,
@@ -1617,7 +1603,7 @@ class OperatorConsoleReadService:
                 matched_tags=item.matched_tags,
                 top_confidence_score=item.top_confidence_score,
                 sort_tag_name=item.sort_tag_name,
-                integrity_status=integrity_status_by_instance.get(UUID(item.id)),
+                integrity_status=None,
             )
             for item in page_rows.items
         )


### PR DESCRIPTION
## Summary

Removes the unreachable secondary \`IntegrityCheck\` lookup from \`OperatorConsoleReadService.get_canonical_gallery()\`.

This PR is intentionally a minimal backend cleanup. It does not change query filtering behavior, frontend behavior, or the \`CanonicalGalleryItem\` response shape.

## What changed

### Dead lookup removal
- removed the post-query \`IntegrityCheck\` lookup from \`get_canonical_gallery()\`
- removed the now-unused locals tied to that lookup:
  - \`canonical_ids\`
  - \`integrity_status_by_instance\`

### Response shape preserved
- kept \`CanonicalGalleryItem.integrity_status\` in place
- continued to populate it, now explicitly as \`None\` for default gallery results

## Scope protection
Did not change:
- \`DiscoveryQueryService\` filtering behavior
- default gallery exclusion behavior for \`BROKEN\` / \`SUSPECT\`
- frontend/UI code
- API/model contracts
- speculative future admin/debug behavior

## Validation

Backend test command:
./.venv/bin/python -m pytest media_manager/tests/test_operator_console_canonical_gallery.py -q

Result:
- 24 passed

## Related

- #118
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
