### PR TITLE
feat(gui): persist Library pagination controls during page loading

### DIFF
--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -83,6 +83,11 @@ export default function GalleryPage() {
   const [selectedFile, setSelectedFile] = useState<CanonicalFile | null>(null);
   const [tagInput, setTagInput] = useState("");
   const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [lastKnownPagination, setLastKnownPagination] = useState<{
+    totalCount: number;
+    totalPages: number;
+    key: string;
+  } | null>(null);
   const tagsParam = searchParams.get("tags") || "";
   const selectedTags = useMemo(() => tagsParam.split(",").filter(Boolean), [tagsParam]);
   const sortBy = searchParams.get("sort_by") || "created_at";
@@ -124,6 +129,16 @@ export default function GalleryPage() {
     }),
     [densityPreset.limit, mediaTypeFilter, page, sortBy, sortOrder, tagsParam],
   );
+  const paginationMetadataKey = useMemo(
+    () => JSON.stringify({
+      limit: densityPreset.limit,
+      tags: tagsParam || undefined,
+      sort_by: sortBy,
+      sort_order: sortOrder,
+      media_type: mediaTypeFilter === "all" ? undefined : mediaTypeFilter,
+    }),
+    [densityPreset.limit, mediaTypeFilter, sortBy, sortOrder, tagsParam],
+  );
 
   const tagsQuery = useQuery({
     queryKey: queryKeys.canonicalTags(""),
@@ -142,7 +157,13 @@ export default function GalleryPage() {
   const allTags = useMemo(() => (tagsQuery.data as Tag[] | undefined) ?? [], [tagsQuery.data]);
   const totalCount = data?.total ?? 0;
   const totalPages = Math.max(data?.total_pages ?? 1, 1);
-  const visiblePages = useMemo(() => getVisiblePages(page, totalPages), [page, totalPages]);
+  const persistedPagination =
+    galleryQuery.isLoading && !data && lastKnownPagination?.key === paginationMetadataKey
+      ? lastKnownPagination
+      : null;
+  const paginationTotalCount = persistedPagination?.totalCount ?? totalCount;
+  const paginationTotalPages = Math.max(persistedPagination?.totalPages ?? totalPages, 1);
+  const visiblePages = useMemo(() => getVisiblePages(page, paginationTotalPages), [page, paginationTotalPages]);
   const hasActiveFilters = selectedTags.length > 0 || mediaTypeFilter !== "all";
   const activeFilterSummary = [
     selectedTags.length ? `${selectedTags.length} tag filter${selectedTags.length === 1 ? "" : "s"}` : null,
@@ -150,6 +171,15 @@ export default function GalleryPage() {
   ]
     .filter(Boolean)
     .join(" · ");
+
+  useEffect(() => {
+    if (!data) return;
+    setLastKnownPagination({
+      totalCount: data.total,
+      totalPages: Math.max(data.total_pages ?? 1, 1),
+      key: paginationMetadataKey,
+    });
+  }, [data, paginationMetadataKey]);
 
   useEffect(() => {
     if (!tagInput) {
@@ -363,7 +393,7 @@ export default function GalleryPage() {
           }
         />
 
-        {data && totalPages > 1 && (
+        {paginationTotalPages > 1 && (
           <Pagination className="justify-center">
             <PaginationContent>
               <PaginationItem>
@@ -403,10 +433,10 @@ export default function GalleryPage() {
                   href="#"
                   onClick={(event) => {
                     event.preventDefault();
-                    if (page >= totalPages) return;
+                    if (page >= paginationTotalPages) return;
                     updateParams({ page: String(page + 1) });
                   }}
-                  className={page >= totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                  className={page >= paginationTotalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
                 />
               </PaginationItem>
             </PaginationContent>

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -608,6 +608,8 @@ describe("Gallery page", () => {
       expect(screen.getByText("Loading gallery...")).toBeInTheDocument();
       expect(screen.queryByText("page-1-image.jpg")).not.toBeInTheDocument();
       expect(screen.queryByText("page-1-video.mp4")).not.toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Go to previous page" })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Go to next page" })).toBeInTheDocument();
     });
 
     resolvePageTwo?.({


### PR DESCRIPTION
## Summary

Keeps Library pagination controls visible during page-only loading transitions without reintroducing stale grid content or page-state mismatch.

This PR is intentionally a minimal Gallery-only UX improvement. It preserves the existing no-stale-content correctness behavior while keeping pagination controls visible from last known pagination metadata during page-only transitions.

## What changed

### Pagination visibility during page-only transitions
- added a small local \`lastKnownPagination\` state in \`GalleryPage.tsx\`
- stored:
  - \`totalCount\`
  - \`totalPages\`
  - a non-page metadata key derived from:
    - \`limit\`
    - \`tags\`
    - \`sort_by\`
    - \`sort_order\`
    - \`media_type\`
- reused the stored pagination metadata only when:
  - the gallery is loading
  - \`data\` is currently null
  - the non-page metadata key still matches

### Correctness preserved
- the media grid still enters loading/skeleton state while the next page is loading
- previous-page media items remain hidden
- non-page transitions continue to behave as before because preserved pagination metadata is ignored when the non-page metadata key changes

### Tests
Updated:
- \`operator_console/gui_app/src/test/gallery-page.test.tsx\`

Verified:
- page 1 items disappear while page 2 is loading
- pagination controls remain visible during that loading state
- page 2 items render after resolution

## Scope protection
Did not change:
- \`placeholderData\`
- previous grid item retention
- backend/API behavior
- query keys
- media-type, tag, density, or sort behavior
- broader Gallery redesign

## Validation

Frontend test command:
cd operator_console/gui_app && npm run test -- src/test/gallery-page.test.tsx

Result:
- 11 passed

## Related

- #109
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
