### PR TITLE
fix(gui): clean up gallery pagination metadata key

### DIFF
--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -130,14 +130,11 @@ export default function GalleryPage() {
     [densityPreset.limit, mediaTypeFilter, page, sortBy, sortOrder, tagsParam],
   );
   const paginationMetadataKey = useMemo(
-    () => JSON.stringify({
-      limit: densityPreset.limit,
-      tags: tagsParam || undefined,
-      sort_by: sortBy,
-      sort_order: sortOrder,
-      media_type: mediaTypeFilter === "all" ? undefined : mediaTypeFilter,
-    }),
-    [densityPreset.limit, mediaTypeFilter, sortBy, sortOrder, tagsParam],
+    () => {
+      const { page: _page, ...paginationParams } = canonicalParams;
+      return JSON.stringify(paginationParams);
+    },
+    [canonicalParams],
   );
 
   const tagsQuery = useQuery({
@@ -161,7 +158,6 @@ export default function GalleryPage() {
     galleryQuery.isLoading && !data && lastKnownPagination?.key === paginationMetadataKey
       ? lastKnownPagination
       : null;
-  const paginationTotalCount = persistedPagination?.totalCount ?? totalCount;
   const paginationTotalPages = Math.max(persistedPagination?.totalPages ?? totalPages, 1);
   const visiblePages = useMemo(() => getVisiblePages(page, paginationTotalPages), [page, paginationTotalPages]);
   const hasActiveFilters = selectedTags.length > 0 || mediaTypeFilter !== "all";

--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -84,7 +84,6 @@ export default function GalleryPage() {
   const [tagInput, setTagInput] = useState("");
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [lastKnownPagination, setLastKnownPagination] = useState<{
-    totalCount: number;
     totalPages: number;
     key: string;
   } | null>(null);
@@ -171,7 +170,6 @@ export default function GalleryPage() {
   useEffect(() => {
     if (!data) return;
     setLastKnownPagination({
-      totalCount: data.total,
       totalPages: Math.max(data.total_pages ?? 1, 1),
       key: paginationMetadataKey,
     });


### PR DESCRIPTION
## Summary
- clean up the post-merge pagination metadata follow-up from PR #123
- derive `paginationMetadataKey` from `canonicalParams` with `page` omitted
- remove the unused pagination count local

## Why
PR #123 merged the intended Library pagination behavior, but a local-only follow-up commit with small review-driven cleanup never got pushed before merge. This PR reapplies only the still-valid cleanup against current `develop`.

## Validation
- `npm run test -- src/test/gallery-page.test.tsx`
- `./.venv/bin/python -m pytest -q`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
