### PR TITLE
feat(gui): prove nav contract on Library Duplicates and Admin

### DIFF
--- a/operator_console/gui_app/src/pages/AdminPage.tsx
+++ b/operator_console/gui_app/src/pages/AdminPage.tsx
@@ -2624,73 +2624,29 @@ export default function AdminPage() {
 
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
-      <TopSurfaceHeader
-        badge="Admin Workspace"
-        title="Review what happened, investigate files, and use advanced tools only when you need them."
-        description="This is one integrated workspace now. Start with the simpler review tools, then move into health checks, benchmarks, or reset only when the situation calls for it."
-        icon={Sparkles}
-        className="rounded-[30px]"
-      >
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <button
-            type="button"
-            onClick={() => updateTab("activity")}
-            className="rounded-2xl border border-border/70 bg-background/85 p-4 text-left shadow-sm transition-colors hover:bg-primary/5"
-          >
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Start here</p>
-            <p className="mt-2 text-base font-semibold">Activity</p>
-            <p className="mt-1 text-sm text-muted-foreground">Review recent jobs and failures first.</p>
-          </button>
-          <button
-            type="button"
-            onClick={() => updateTab("file-history")}
-            className="rounded-2xl border border-border/70 bg-background/85 p-4 text-left shadow-sm transition-colors hover:bg-primary/5"
-          >
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Find answers</p>
-            <p className="mt-2 text-base font-semibold">File History</p>
-            <p className="mt-1 text-sm text-muted-foreground">Investigate a file by path, fingerprint, or state.</p>
-          </button>
-          <button
-            type="button"
-            onClick={() => updateTab("library-rules")}
-            className="rounded-2xl border border-border/70 bg-background/85 p-4 text-left shadow-sm transition-colors hover:bg-primary/5"
-          >
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Set behavior</p>
-            <p className="mt-2 text-base font-semibold">Library Rules</p>
-            <p className="mt-1 text-sm text-muted-foreground">Choose which copy should stay primary.</p>
-          </button>
-          <button
-            type="button"
-            onClick={() => updateTab("system-health")}
-            className="rounded-2xl border border-border/70 bg-background/85 p-4 text-left shadow-sm transition-colors hover:bg-primary/5"
-          >
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Advanced</p>
-            <p className="mt-2 text-base font-semibold">System Health</p>
-            <p className="mt-1 text-sm text-muted-foreground">Check broader health and monitoring signals.</p>
-          </button>
-          <button
-            type="button"
-            onClick={() => updateTab("reset")}
-            className="rounded-2xl border border-destructive/25 bg-background/85 p-4 text-left shadow-sm transition-colors hover:bg-destructive/5"
-          >
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-destructive">Danger zone</p>
-            <p className="mt-2 text-base font-semibold">Reset</p>
-            <p className="mt-1 text-sm text-muted-foreground">Preview or clear data only in controlled environments.</p>
-          </button>
-        </div>
-      </TopSurfaceHeader>
+      <div data-testid="admin-page-header">
+        <TopSurfaceHeader
+          badge="Admin Workspace"
+          title="Review what happened, investigate files, and use advanced tools only when you need them."
+          description="This is one integrated workspace now. Start with the simpler review tools, then move into health checks, benchmarks, or reset only when the situation calls for it."
+          icon={Sparkles}
+          className="rounded-[30px]"
+        />
+      </div>
 
       <Tabs value={tab} onValueChange={(value) => updateTab(value as AdminTab)} className="space-y-4">
-        <TabsList className="flex h-auto w-full flex-wrap justify-start gap-1 rounded-2xl p-1">
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="activity">Activity</TabsTrigger>
-          <TabsTrigger value="library-rules">Library Rules</TabsTrigger>
-          <TabsTrigger value="file-history">File History</TabsTrigger>
-          <TabsTrigger value="integrity-check">Integrity Check</TabsTrigger>
-          <TabsTrigger value="system-health">System Health</TabsTrigger>
-          <TabsTrigger value="benchmarks">Performance Lab</TabsTrigger>
-          <TabsTrigger value="reset">Reset</TabsTrigger>
-        </TabsList>
+        <section data-page-section-nav data-testid="admin-page-section-nav">
+          <TabsList className="flex h-auto w-full flex-wrap justify-start gap-1 rounded-2xl p-1">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="activity">Activity</TabsTrigger>
+            <TabsTrigger value="library-rules">Library Rules</TabsTrigger>
+            <TabsTrigger value="file-history">File History</TabsTrigger>
+            <TabsTrigger value="integrity-check">Integrity Check</TabsTrigger>
+            <TabsTrigger value="system-health">System Health</TabsTrigger>
+            <TabsTrigger value="benchmarks">Performance Lab</TabsTrigger>
+            <TabsTrigger value="reset">Reset</TabsTrigger>
+          </TabsList>
+        </section>
 
         <TabsContent value="overview"><OverviewTab setTab={updateTab} /></TabsContent>
         <TabsContent value="activity"><ActivityTab /></TabsContent>

--- a/operator_console/gui_app/src/pages/AdminPage.tsx
+++ b/operator_console/gui_app/src/pages/AdminPage.tsx
@@ -2624,7 +2624,7 @@ export default function AdminPage() {
 
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
-      <div data-testid="admin-page-header">
+      <div data-page-header data-testid="admin-page-header">
         <TopSurfaceHeader
           badge="Admin Workspace"
           title="Review what happened, investigate files, and use advanced tools only when you need them."

--- a/operator_console/gui_app/src/pages/DuplicatesPage.tsx
+++ b/operator_console/gui_app/src/pages/DuplicatesPage.tsx
@@ -1540,8 +1540,8 @@ export default function DuplicatesPage() {
       ) : (
         <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as DuplicatesTab)} className="space-y-3">
           <section
-            data-page-controls
-            data-testid="duplicates-page-controls"
+            data-page-section-nav
+            data-testid="duplicates-page-section-nav"
             className="rounded-[24px] border border-border/70 bg-card/95 p-1 shadow-sm"
           >
             <TabsList className="flex h-auto w-full flex-wrap justify-start gap-2 rounded-[18px] bg-muted/60 p-1">

--- a/operator_console/gui_app/src/pages/GalleryPage.tsx
+++ b/operator_console/gui_app/src/pages/GalleryPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Link, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { ErrorAlert } from "@/components/ErrorAlert";
 import { PageShell } from "@/components/layout/PageShell";
 import { MediaGrid } from "@/components/media/MediaGrid";
@@ -206,13 +206,6 @@ export default function GalleryPage() {
             {galleryQuery.isLoading && !data
               ? "Loading gallery..."
               : `${totalCount} item${totalCount === 1 ? "" : "s"} · Page ${page} of ${totalPages}`}
-          </div>
-          <div className="rounded-2xl border border-border/70 bg-background/85 px-4 py-3 text-sm text-muted-foreground shadow-sm">
-            Problem items belong in{" "}
-            <Link to="/integrity" className="font-medium text-foreground underline underline-offset-4">
-              Integrity Checks
-            </Link>
-            .
           </div>
         </div>
 

--- a/operator_console/gui_app/src/test/admin-page.test.tsx
+++ b/operator_console/gui_app/src/test/admin-page.test.tsx
@@ -292,6 +292,11 @@ describe("Admin page", () => {
   it("renders the live progress panel in the activity detail rail", async () => {
     renderPage();
 
+    const pageHeader = screen.getByTestId("admin-page-header");
+    const sectionNav = screen.getByTestId("admin-page-section-nav");
+    expect(pageHeader.querySelector("button")).toBeNull();
+    expect(pageHeader.querySelector("a")).toBeNull();
+    expect(sectionNav).toBeInTheDocument();
     expect(await screen.findByRole("tab", { name: "Activity" })).toBeInTheDocument();
     expect(screen.getByText("What happened in this job")).toBeInTheDocument();
     expect(await screen.findByText("[ WAITING FOR LOGS ]")).toBeInTheDocument();

--- a/operator_console/gui_app/src/test/admin-page.test.tsx
+++ b/operator_console/gui_app/src/test/admin-page.test.tsx
@@ -297,6 +297,7 @@ describe("Admin page", () => {
     expect(pageHeader.querySelector("button")).toBeNull();
     expect(pageHeader.querySelector("a")).toBeNull();
     expect(sectionNav).toBeInTheDocument();
+    expect(sectionNav.querySelector('[role="tablist"]')).not.toBeNull();
     expect(await screen.findByRole("tab", { name: "Activity" })).toBeInTheDocument();
     expect(screen.getByText("What happened in this job")).toBeInTheDocument();
     expect(await screen.findByText("[ WAITING FOR LOGS ]")).toBeInTheDocument();

--- a/operator_console/gui_app/src/test/duplicates-page.test.tsx
+++ b/operator_console/gui_app/src/test/duplicates-page.test.tsx
@@ -293,17 +293,17 @@ describe("DuplicatesPage", () => {
   it("defaults to the review tab with comparison content dominant and no Recycle Bin actions", async () => {
     renderPage();
 
-    const pageControls = await screen.findByTestId("duplicates-page-controls");
+    const sectionNav = await screen.findByTestId("duplicates-page-section-nav");
     const pageHeader = screen.getByTestId("duplicates-page-header");
     expect(within(pageHeader).queryByRole("button")).toBeNull();
     expect(within(pageHeader).queryByRole("link")).toBeNull();
 
-    expect(within(pageControls).getByRole("tab", { name: "Review duplicates" })).toBeInTheDocument();
-    expect(within(pageControls).getByRole("tab", { name: "Ready for Bin" })).toBeInTheDocument();
-    expect(within(pageControls).getByRole("tab", { name: "Recycle Bin" })).toBeInTheDocument();
-    expect(within(pageControls).getByRole("tab", { name: "Playback issues" })).toBeInTheDocument();
+    expect(within(sectionNav).getByRole("tab", { name: "Review duplicates" })).toBeInTheDocument();
+    expect(within(sectionNav).getByRole("tab", { name: "Ready for Bin" })).toBeInTheDocument();
+    expect(within(sectionNav).getByRole("tab", { name: "Recycle Bin" })).toBeInTheDocument();
+    expect(within(sectionNav).getByRole("tab", { name: "Playback issues" })).toBeInTheDocument();
     const sharedHeading = screen.getByTestId("duplicates-shared-tab-heading");
-    expect(pageControls.nextElementSibling).toBe(sharedHeading);
+    expect(sectionNav.nextElementSibling).toBe(sharedHeading);
     expect(sharedHeading).toHaveTextContent("Review duplicates");
 
     expect(await screen.findByRole("heading", { name: "Review duplicates" })).toBeInTheDocument();
@@ -515,9 +515,9 @@ describe("DuplicatesPage", () => {
 
     renderPage("/duplicates?tab=removal");
 
-    const pageControls = await screen.findByTestId("duplicates-page-controls");
+    const sectionNav = await screen.findByTestId("duplicates-page-section-nav");
     const sharedHeading = screen.getByTestId("duplicates-shared-tab-heading");
-    expect(pageControls.nextElementSibling).toBe(sharedHeading);
+    expect(sectionNav.nextElementSibling).toBe(sharedHeading);
     expect(sharedHeading).toHaveTextContent("Ready for Bin");
     expect(await screen.findByRole("heading", { name: "Ready for Bin" })).toBeInTheDocument();
     expect(screen.getAllByText("Ready for Bin").length).toBeGreaterThan(0);

--- a/operator_console/gui_app/src/test/gallery-page.test.tsx
+++ b/operator_console/gui_app/src/test/gallery-page.test.tsx
@@ -100,13 +100,13 @@ describe("Gallery page", () => {
     expect(screen.getByRole("radio", { name: "All" })).toHaveAttribute("aria-checked", "true");
   });
 
-  it("states the default library visibility rule and provides a Gallery-level handoff to Integrity Checks", async () => {
+  it("states the default library visibility rule without adding Gallery-level Integrity navigation", async () => {
     renderPage();
 
     expect(await screen.findByText(/Library shows usable media by default\./)).toBeInTheDocument();
     expect(screen.getByText(/Items marked BROKEN or SUSPECT are excluded from default browsing\./)).toBeInTheDocument();
-    expect(screen.getByText(/Problem items belong in/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Integrity Checks" })).toHaveAttribute("href", "/integrity");
+    expect(screen.queryByText(/Problem items belong in/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Integrity Checks" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /integrity/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: /integrity/i })).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- remove duplicated cross-area navigation from Library top controls surface
- treat Duplicates tabs as section/workflow navigation rather than controls
- remove duplicated Admin header navigation and keep one section-navigation surface

## What changed

### Library
- removed the Gallery-level Integrity Checks handoff from the top controls/status area
- preserved orientation-only header
- kept the controls surface limited to local browsing controls and page-state info

### Duplicates
- moved page tabs out of the controls-designated surface
- treated tabs as the page's dedicated section/workflow navigation surface
- preserved orientation-only header and inline review/bin actions

### Admin
- removed header navigation cards that duplicated the tab strip
- kept the tab strip as the single surviving section-navigation surface
- preserved orientation-only header and tab-specific work below

## Scope protection
Did not change:
- \`PageShell.tsx\`
- Dashboard
- Operations
- Organize
- broader navigation rollout beyond the three proof pages

## Validation
- \`cd operator_console/gui_app && npm run test -- src/test/gallery-page.test.tsx src/test/duplicates-page.test.tsx src/test/admin-page.test.tsx\`

## Related
- #128
- #13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
