### PR TITLE
feat(gui): roll out nav contract to Dashboard Operations and Organize

### DIFF
--- a/operator_console/gui_app/src/components/wizard/WizardProgressHeader.tsx
+++ b/operator_console/gui_app/src/components/wizard/WizardProgressHeader.tsx
@@ -1,7 +1,6 @@
 import { Check, Lock, OctagonAlert, type LucideIcon } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-import type { ReactNode } from "react";
 
 export type WizardProgressStatus = "completed" | "current" | "pending" | "failed" | "blocked";
 
@@ -21,7 +20,6 @@ interface WizardProgressHeaderProps {
   previousTitle?: string | null;
   nextTitle?: string | null;
   items: WizardProgressItem[];
-  secondaryAction?: ReactNode;
 }
 
 function StepMarker({
@@ -92,24 +90,20 @@ export function WizardProgressHeader({
   previousTitle,
   nextTitle,
   items,
-  secondaryAction,
 }: WizardProgressHeaderProps) {
   return (
     <Card className="rounded-2xl border-border/80 bg-card/80 shadow-sm">
       <CardContent className="space-y-2.5 p-4">
-        <div className="flex items-center justify-between gap-4">
-          <div className="min-w-0 flex-1 space-y-1.5">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Progress</p>
-            <div className="flex items-center gap-2">
-              {items.map((item, index) => (
-                <div key={item.id} className="flex min-w-0 flex-1 items-center gap-2">
-                  <StepMarker status={item.status} stepNumber={index + 1} title={item.title} />
-                  {index < items.length - 1 && <StepConnector active={item.status === "completed" || item.status === "current"} />}
-                </div>
-              ))}
-            </div>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Progress</p>
+          <div className="flex items-center gap-2">
+            {items.map((item, index) => (
+              <div key={item.id} className="flex min-w-0 flex-1 items-center gap-2">
+                <StepMarker status={item.status} stepNumber={index + 1} title={item.title} />
+                {index < items.length - 1 && <StepConnector active={item.status === "completed" || item.status === "current"} />}
+              </div>
+            ))}
           </div>
-          {secondaryAction}
         </div>
 
         <div className="space-y-0.5">

--- a/operator_console/gui_app/src/pages/DashboardPage.tsx
+++ b/operator_console/gui_app/src/pages/DashboardPage.tsx
@@ -185,9 +185,9 @@ export default function DashboardPage() {
   const home = homeQuery.data;
   const error = getErrorMessage(homeQuery.error);
   const recentImages =
-    home?.recent_images ?? home?.recent_media.filter((file) => file.file_type === "image") ?? [];
+    home?.recent_images ?? (home?.recent_media ?? []).filter((file) => file.file_type === "image");
   const recentVideos =
-    home?.recent_videos ?? home?.recent_media.filter((file) => file.file_type === "video") ?? [];
+    home?.recent_videos ?? (home?.recent_media ?? []).filter((file) => file.file_type === "video");
   const secondary = home ? (
     <div className="space-y-6 xl:sticky xl:top-6 xl:self-start">
       <Card className="rounded-[28px] border-border/70 bg-background/90 shadow-sm">
@@ -197,7 +197,7 @@ export default function DashboardPage() {
         </CardHeader>
         <CardContent className="space-y-3">
           <p className="text-sm leading-6 text-muted-foreground">
-            {home.guided_entry?.helper ?? "Guided ingest, planning, apply, and review"}
+            Canonical media currently available for browsing, review, and follow-up work.
           </p>
           <LibrarySummaryCards
             totalAssets={home.library_summary.total_assets}

--- a/operator_console/gui_app/src/pages/DashboardPage.tsx
+++ b/operator_console/gui_app/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { ErrorAlert } from "@/components/ErrorAlert";
@@ -12,7 +12,7 @@ import { getHome } from "@/lib/api/endpoints";
 import { queryKeys } from "@/lib/api/queryKeys";
 import { queryOptions } from "@/lib/api/queryOptions";
 import type { CanonicalFile, HomePageData } from "@/types";
-import { ArrowRight, Copy, ImageIcon, Images, Video } from "lucide-react";
+import { ArrowRight, ImageIcon, Video } from "lucide-react";
 
 function getErrorMessage(err: unknown): string | null {
   if (!err) return null;
@@ -105,33 +105,6 @@ function SectionHeader({
   );
 }
 
-function QuickLinkCard({
-  title,
-  description,
-  href,
-  icon,
-}: {
-  title: string;
-  description: string;
-  href: string;
-  icon: ReactNode;
-}) {
-  return (
-    <Link
-      to={href}
-      className="rounded-2xl border border-border/70 bg-background/80 p-4 shadow-sm transition-colors hover:border-primary/35 hover:bg-primary/5"
-    >
-      <div className="flex items-start gap-3">
-        <div className="rounded-xl border border-border/70 bg-card p-2">{icon}</div>
-        <div className="min-w-0">
-          <p className="text-sm font-semibold text-foreground">{title}</p>
-          <p className="mt-1 text-sm leading-6 text-muted-foreground">{description}</p>
-        </div>
-      </div>
-    </Link>
-  );
-}
-
 function SummarySkeleton() {
   return (
     <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
@@ -215,48 +188,23 @@ export default function DashboardPage() {
     home?.recent_images ?? home?.recent_media.filter((file) => file.file_type === "image") ?? [];
   const recentVideos =
     home?.recent_videos ?? home?.recent_media.filter((file) => file.file_type === "video") ?? [];
-  const controls =
-    homeQuery.isLoading && !home ? (
-      <SummarySkeleton />
-    ) : home ? (
-      <LibrarySummaryCards
-        totalAssets={home.library_summary.total_assets}
-        images={home.library_summary.images}
-        videos={home.library_summary.videos}
-        duplicateGroups={home.library_summary.duplicate_groups}
-      />
-    ) : null;
   const secondary = home ? (
     <div className="space-y-6 xl:sticky xl:top-6 xl:self-start">
       <Card className="rounded-[28px] border-border/70 bg-background/90 shadow-sm">
         <CardHeader className="pb-3">
-          <CardDescription>Go where you need to work</CardDescription>
-          <CardTitle className="text-xl">Quick Links</CardTitle>
+          <CardDescription>Overview of the current library state</CardDescription>
+          <CardTitle className="text-xl">Library Snapshot</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
-          <Button asChild className="w-full justify-between">
-            <Link to={home.guided_entry?.route ?? "/pipeline-wizard"}>
-              {home.guided_entry?.label ?? "Open Organize"}
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          </Button>
           <p className="text-sm leading-6 text-muted-foreground">
             {home.guided_entry?.helper ?? "Guided ingest, planning, apply, and review"}
           </p>
-          <div className="grid gap-3 pt-2">
-            <QuickLinkCard
-              title="Duplicate Review"
-              description="Inspect duplicate groups and confirm which items need review."
-              href="/duplicates"
-              icon={<Copy className="h-4 w-4" />}
-            />
-            <QuickLinkCard
-              title="Open Library"
-              description="Browse canonical media with previews, filters, and detail pages."
-              href="/gallery"
-              icon={<Images className="h-4 w-4" />}
-            />
-          </div>
+          <LibrarySummaryCards
+            totalAssets={home.library_summary.total_assets}
+            images={home.library_summary.images}
+            videos={home.library_summary.videos}
+            duplicateGroups={home.library_summary.duplicate_groups}
+          />
         </CardContent>
       </Card>
 
@@ -266,26 +214,20 @@ export default function DashboardPage() {
           <CardTitle className="text-xl">Needs Attention</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
-          <Link
-            to="/duplicates"
-            className="flex items-center justify-between rounded-2xl border border-border/70 bg-background/80 p-4 transition-colors hover:border-primary/35 hover:bg-primary/5"
-          >
+          <div className="flex items-center justify-between rounded-2xl border border-border/70 bg-background/80 p-4">
             <div>
               <p className="text-sm font-semibold">Duplicate groups</p>
               <p className="mt-1 text-sm text-muted-foreground">Review likely duplicate clusters.</p>
             </div>
             <span className="text-2xl font-semibold">{home.attention_summary.duplicate_groups}</span>
-          </Link>
-          <Link
-            to="/admin?tab=activity"
-            className="flex items-center justify-between rounded-2xl border border-border/70 bg-background/80 p-4 transition-colors hover:border-primary/35 hover:bg-primary/5"
-          >
+          </div>
+          <div className="flex items-center justify-between rounded-2xl border border-border/70 bg-background/80 p-4">
             <div>
               <p className="text-sm font-semibold">Failed runs</p>
-              <p className="mt-1 text-sm text-muted-foreground">Open Admin Diagnostics to review jobs that need follow-up.</p>
+              <p className="mt-1 text-sm text-muted-foreground">Jobs that need follow-up.</p>
             </div>
             <span className="text-2xl font-semibold">{home.attention_summary.failed_runs}</span>
-          </Link>
+          </div>
           <div className="flex items-center justify-between rounded-2xl border border-border/70 bg-background/80 p-4">
             <div>
               <p className="text-sm font-semibold">Untagged assets</p>
@@ -315,10 +257,11 @@ export default function DashboardPage() {
       variant="standard-admin"
       title="Media Manager"
       description="Browse recent media, review what needs attention, and jump into the guided workflow when you're ready."
-      controls={controls}
       secondary={secondary}
     >
       {error ? <ErrorAlert message={error} /> : null}
+
+      {homeQuery.isLoading && !home ? <SummarySkeleton /> : null}
 
       {home ? (
         <div className="space-y-6">

--- a/operator_console/gui_app/src/pages/OperationsPage.tsx
+++ b/operator_console/gui_app/src/pages/OperationsPage.tsx
@@ -706,18 +706,6 @@ export default function OperationsPage() {
         />
       </div>
 
-      <section data-page-controls data-testid="operations-page-controls" className="flex flex-wrap gap-3">
-        <Button asChild size="sm">
-          <Link to="/pipeline-wizard">
-            Open Organize
-            <ArrowRight className="ml-2 h-4 w-4" />
-          </Link>
-        </Button>
-        <Button asChild variant="outline" size="sm">
-          <Link to="/admin?tab=activity">Review Activity</Link>
-        </Button>
-      </section>
-
       {/* Keep one shared live panel above the action sections so progress stays visible while users move between explicit operation controls. */}
       <LiveProgressPanel
         operationKind={activeProgressState?.kind}

--- a/operator_console/gui_app/src/pages/PipelineWizard.tsx
+++ b/operator_console/gui_app/src/pages/PipelineWizard.tsx
@@ -2320,7 +2320,8 @@ export default function PipelineWizard() {
         variant="workflow"
         title="Organize"
         description="Guided ingest, planning, apply, chosen-version review, and enrichment with short checkpoints between stages."
-        controls={
+      >
+        <section data-page-section-nav data-testid="pipeline-wizard-section-nav">
           <WizardProgressHeader
             currentIndex={currentStepIndex}
             totalSteps={STEP_ORDER.length}
@@ -2329,18 +2330,19 @@ export default function PipelineWizard() {
             previousTitle={previousStepTitle}
             nextTitle={nextStepTitle}
             items={progressItems}
-            secondaryAction={
-              currentStepId === "summary" ? null : (
-                <Button type="button" variant="ghost" onClick={() => setConfirmAbortOpen(true)}>
-                  <XCircle className="mr-2 h-4 w-4" />
-                  Abort Wizard
-                </Button>
-              )
-            }
           />
-        }
-      >
-        <div data-page-primary-surface className="-mt-1">
+        </section>
+
+        {currentStepId === "summary" ? null : (
+          <div className="flex justify-end" data-testid="pipeline-wizard-actions">
+            <Button type="button" variant="ghost" onClick={() => setConfirmAbortOpen(true)}>
+              <XCircle className="mr-2 h-4 w-4" />
+              Abort Wizard
+            </Button>
+          </div>
+        )}
+
+        <div data-page-primary-surface className="space-y-4">
           {renderCurrentStep()}
         </div>
       </PageShell>

--- a/operator_console/gui_app/src/test/dashboard-page.test.tsx
+++ b/operator_console/gui_app/src/test/dashboard-page.test.tsx
@@ -75,7 +75,7 @@ describe("Dashboard page", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the standard admin shell with quick links in the supporting rail", async () => {
+  it("renders the standard admin shell without duplicating cross-area navigation cards", async () => {
     renderPage();
 
     expect(await screen.findByText("Media Manager")).toBeInTheDocument();
@@ -83,7 +83,9 @@ describe("Dashboard page", () => {
       screen.getByText("Browse recent media, review what needs attention, and jump into the guided workflow when you're ready."),
     ).toBeInTheDocument();
     expect(document.querySelector('[data-page-shell="standard-admin"]')).toBeTruthy();
-    expect(await screen.findByRole("link", { name: "Open Organize" })).toBeInTheDocument();
-    expect(screen.getByText("Quick Links")).toBeInTheDocument();
+    expect(screen.queryByText("Quick Links")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Open Organize" })).not.toBeInTheDocument();
+    expect(await screen.findByText("Library Snapshot")).toBeInTheDocument();
+    expect(screen.getByText("Needs Attention")).toBeInTheDocument();
   });
 });

--- a/operator_console/gui_app/src/test/dashboard-page.test.tsx
+++ b/operator_console/gui_app/src/test/dashboard-page.test.tsx
@@ -62,6 +62,7 @@ describe("Dashboard page", () => {
           last_run_type: "PLAN",
           regression_status: "UNKNOWN",
         },
+        // Retained to mirror the backend payload even though Dashboard no longer renders it.
         guided_entry: {
           label: "Open Organize",
           route: "/pipeline-wizard",

--- a/operator_console/gui_app/src/test/library-actions-page.test.tsx
+++ b/operator_console/gui_app/src/test/library-actions-page.test.tsx
@@ -221,13 +221,10 @@ describe("Import page", () => {
     expect(screen.getByText("Add Searchable Details")).toBeInTheDocument();
     expect(screen.queryByText("Legacy Composite Run")).not.toBeInTheDocument();
     expect(screen.queryByText("Mutating")).not.toBeInTheDocument();
-    const pageControls = screen.getByTestId("operations-page-controls");
     const pageHeader = screen.getByTestId("operations-page-header");
     expect(within(pageHeader).queryByRole("link")).toBeNull();
     expect(within(pageHeader).queryByRole("button")).toBeNull();
-
-    expect(within(pageControls).getByRole("link", { name: "Open Organize" })).toBeInTheDocument();
-    expect(within(pageControls).getByRole("link", { name: "Review Activity" })).toBeInTheDocument();
+    expect(screen.queryByTestId("operations-page-controls")).not.toBeInTheDocument();
     expect(await screen.findByText("[ WAITING FOR LOGS ]")).toBeInTheDocument();
   });
 

--- a/operator_console/gui_app/src/test/pipeline-wizard-page.test.tsx
+++ b/operator_console/gui_app/src/test/pipeline-wizard-page.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -104,10 +104,12 @@ describe("Pipeline Wizard page", () => {
       ),
     ).toBeInTheDocument();
     expect(document.querySelector('[data-page-shell="workflow"]')).toBeTruthy();
-    expect(screen.getByTestId("pipeline-wizard-section-nav")).toBeInTheDocument();
-    expect(screen.queryByTestId("pipeline-wizard-section-nav")?.querySelector("button")).toBeNull();
-    expect(screen.getByTestId("pipeline-wizard-actions")).toBeInTheDocument();
-    expect(screen.getByTestId("pipeline-wizard-actions").querySelector("button")).not.toBeNull();
+    const sectionNav = screen.getByTestId("pipeline-wizard-section-nav");
+    const actions = screen.getByTestId("pipeline-wizard-actions");
+    expect(sectionNav).toBeInTheDocument();
+    expect(within(sectionNav).queryByRole("button", { name: "Abort Wizard" })).toBeNull();
+    expect(actions).toBeInTheDocument();
+    expect(within(actions).getByRole("button", { name: "Abort Wizard" })).toBeInTheDocument();
     expect(document.querySelector("[data-page-shell-controls]")).toBeFalsy();
     expect(document.querySelector("[data-page-primary-surface]")).toBeTruthy();
     expect(screen.getAllByText("Progress").length).toBeGreaterThan(0);

--- a/operator_console/gui_app/src/test/pipeline-wizard-page.test.tsx
+++ b/operator_console/gui_app/src/test/pipeline-wizard-page.test.tsx
@@ -104,7 +104,11 @@ describe("Pipeline Wizard page", () => {
       ),
     ).toBeInTheDocument();
     expect(document.querySelector('[data-page-shell="workflow"]')).toBeTruthy();
-    expect(document.querySelector("[data-page-shell-controls]")).toBeTruthy();
+    expect(screen.getByTestId("pipeline-wizard-section-nav")).toBeInTheDocument();
+    expect(screen.queryByTestId("pipeline-wizard-section-nav")?.querySelector("button")).toBeNull();
+    expect(screen.getByTestId("pipeline-wizard-actions")).toBeInTheDocument();
+    expect(screen.getByTestId("pipeline-wizard-actions").querySelector("button")).not.toBeNull();
+    expect(document.querySelector("[data-page-shell-controls]")).toBeFalsy();
     expect(document.querySelector("[data-page-primary-surface]")).toBeTruthy();
     expect(screen.getAllByText("Progress").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Abort Wizard" })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- remove Operations top-row navigation that duplicated cross-area movement
- remove Dashboard routing surfaces that duplicated sidebar navigation and stop using the controls slot for summary content
- separate Organize workflow navigation from the Abort Wizard action

## What changed

### Operations
- removed the top page-controls navigation row
- preserved orientation-only header
- kept operation-specific actions inside the existing work panels

### Dashboard
- removed duplicated cross-area routing surfaces such as Quick Links and linked Needs Attention cards
- removed summary metrics from the \`PageShell.controls\` slot
- kept overview/supporting content in the page body or supporting rail
- preserved content-tied actions such as recent-media preview and \`View All Media\`

### Organize
- removed \`Abort Wizard\` from the workflow navigation surface
- kept \`WizardProgressHeader\` as workflow navigation/orientation only
- re-homed \`Abort Wizard\` into a separate page action surface
- preserved step-specific actions inline with wizard content

## Scope protection
Did not change:
- \`PageShell.tsx\`
- Library
- Duplicates
- Admin
- backend/API behavior
- broader redesign or new shared layout abstractions

## Validation
- \`cd operator_console/gui_app && npm run test -- src/test/library-actions-page.test.tsx src/test/dashboard-page.test.tsx src/test/pipeline-wizard-page.test.tsx\`

## Related
- #129
- #13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
