### PR TITLE
test(ci): restore gallery page test to gui-fast lane

### DIFF
--- a/.github/workflows/tests-fast.yml
+++ b/.github/workflows/tests-fast.yml
@@ -80,6 +80,7 @@ jobs:
           src/test/log-progress-parser.test.ts
           src/test/duplicate-group-mapping.test.ts
           src/test/dashboard-page.test.tsx
+          src/test/gallery-page.test.tsx
           src/test/media-gallery.test.tsx
           src/test/sidebar-progress-widget.test.tsx
 


### PR DESCRIPTION
## Summary
- restore \`gallery-page.test.tsx\` to the \`gui-fast\` CI lane
- keep the change limited to workflow configuration
- verify that the restored command shape exits cleanly without reproducing the original hang

## What changed
- added \`src/test/gallery-page.test.tsx\` back into the \`gui-fast\` Vitest allowlist in \`tests-fast.yml\`

## Scope protection
Did not change:
- Gallery app code
- test logic
- broader CI workflow structure
- other GUI lanes

## Validation
- \`cd operator_console/gui_app && npx vitest run --maxWorkers=1 src/test/gallery-page.test.tsx\`
- \`cd operator_console/gui_app && npx vitest run --maxWorkers=1 src/test/api-client.test.ts src/test/api-endpoints.test.ts src/test/log-progress-parser.test.ts src/test/duplicate-group-mapping.test.ts src/test/dashboard-page.test.tsx src/test/gallery-page.test.tsx src/test/media-gallery.test.tsx src/test/sidebar-progress-widget.test.tsx\`

## Related
- #71
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
