### PR TITLE
refactor(backend): pass TagSource through canonical read boundary

### DIFF
--- a/media_manager/app/service_layer/reads.py
+++ b/media_manager/app/service_layer/reads.py
@@ -272,10 +272,9 @@ class ReadServices:
         sort_by: str,
         sort_order: str | None,
         file_type: str | None,
-        source: str | None,
+        source: TagSource | None,
         min_confidence: float | None,
     ) -> dict[str, object]:
-        source_value = TagSource(source.strip().lower()) if source else None
         return self._read_service.get_canonical_gallery(
             page=page,
             limit=limit,
@@ -283,7 +282,7 @@ class ReadServices:
             sort_by=sort_by,
             sort_order=sort_order,
             file_type=file_type,
-            source=source_value,
+            source=source,
             min_confidence=min_confidence,
         ).to_dict()
 

--- a/operator_console/main.py
+++ b/operator_console/main.py
@@ -883,7 +883,7 @@ def create_app() -> FastAPI:
                 sort_by=parsed.sort_by,
                 sort_order=parsed.sort_order,
                 file_type=parsed.file_type,
-                source=parsed.source.value if parsed.source is not None else None,
+                source=parsed.source,
                 min_confidence=parsed.min_confidence,
             ),
         )


### PR DESCRIPTION
## Summary
- remove the redundant enum -> string -> enum round-trip for \`source\` in the canonical read path
- pass \`TagSource | None\` through the internal boundary directly
- preserve existing behavior and filtering semantics

## What changed
- \`canonical_gallery_v2()\` now passes \`parsed.source\` directly instead of \`parsed.source.value\`
- \`ReadServices.canonical()\` now accepts \`TagSource | None\`
- removed the redundant string re-parse inside \`ReadServices.canonical()\`

## Scope protection
Did not change:
- external API behavior
- query parsing behavior
- filtering semantics
- unrelated enum or service-layer cleanup

## Validation
- \`./.venv/bin/python -m pytest media_manager/tests/test_service_layer_reads.py -q\`
- \`./.venv/bin/python -m pytest operator_console/tests/test_main.py -q -k canonical\`

## Related
- #104
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
