### PR TITLE
fix(gui): wrap long paths in Integrity file detail displays

### DIFF
--- a/operator_console/gui_app/src/pages/IntegrityPage.tsx
+++ b/operator_console/gui_app/src/pages/IntegrityPage.tsx
@@ -525,7 +525,7 @@ export default function IntegrityPage() {
                       <div className="flex items-start justify-between gap-4">
                         <div>
                           <p className="font-medium">{basename(issue.absolute_path)}</p>
-                          <p className="mt-1 text-xs text-muted-foreground">{issue.absolute_path}</p>
+                          <p className="mt-1 break-all text-xs text-muted-foreground">{issue.absolute_path}</p>
                         </div>
                         <span className={`rounded-full border px-2.5 py-1 text-xs font-medium ${statusTone(issue.status)}`}>
                           {issue.status}
@@ -572,7 +572,7 @@ export default function IntegrityPage() {
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <p className="text-lg font-semibold">{basename(detail.absolute_path)}</p>
-                    <p className="mt-1 text-xs text-muted-foreground">{detail.absolute_path}</p>
+                    <p className="mt-1 break-all text-xs text-muted-foreground">{detail.absolute_path}</p>
                   </div>
                   <div className={`rounded-full border px-3 py-1 text-xs font-medium ${statusTone(detail.status)}`}>
                     {detail.status}

--- a/operator_console/gui_app/src/test/integrity-page.test.tsx
+++ b/operator_console/gui_app/src/test/integrity-page.test.tsx
@@ -223,13 +223,10 @@ describe("IntegrityPage", () => {
 
     await screen.findByText("Last checked for this file");
 
-    const pathNodes = Array.from(document.querySelectorAll("p.break-all")).filter(
-      (node) => node.textContent === longPath,
-    );
+    const pathNodes = screen.getAllByText(longPath);
     expect(pathNodes).toHaveLength(2);
-    for (const node of pathNodes) {
-      expect(node).toHaveClass("break-all");
-    }
+    expect(pathNodes[0]).toHaveClass("break-all");
+    expect(pathNodes[1]).toHaveClass("break-all");
   });
 
   it("quick scan shows in-flight state and then success summary", async () => {

--- a/operator_console/gui_app/src/test/integrity-page.test.tsx
+++ b/operator_console/gui_app/src/test/integrity-page.test.tsx
@@ -175,6 +175,63 @@ describe("IntegrityPage", () => {
     expect(screen.getAllByText("ffprobe_failed").length).toBeGreaterThan(0);
   });
 
+  it("wraps long raw paths in the queue and file detail while keeping the full value visible", async () => {
+    const longPath = "/media/very/long/path/with/unbroken-segments/that/should/not/overflow/the/integrity/detail/panel/problem-file-with-a-very-long-name-and-no-natural-breakpoints-1234567890abcdef.mp4";
+
+    mocks.getIntegrityIssues.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            check_id: "check-1",
+            file_instance_id: "file-1",
+            absolute_path: longPath,
+            status: "BROKEN",
+            confidence: 0.93,
+            probe_status: "FAILED",
+            decode_status: "SKIPPED",
+            reviewed_decision: null,
+            reviewed_at: null,
+            signal_types: ["ffprobe_failed"],
+          },
+        ],
+      },
+    });
+    mocks.getIntegrityFile.mockResolvedValueOnce({
+      data: {
+        check_id: "check-1",
+        file_instance_id: "file-1",
+        absolute_path: longPath,
+        status: "BROKEN",
+        confidence: 0.93,
+        last_checked_at: "2026-03-25T09:00:00+00:00",
+        probe_status: "FAILED",
+        decode_status: "SKIPPED",
+        reviewed_decision: "MARK_OK",
+        reviewed_at: "2026-03-25T11:00:00+00:00",
+        signals: [
+          {
+            signal_type: "ffprobe_failed",
+            severity: "error",
+            details: { stderr: "bad file" },
+            created_at: "2026-03-25T10:00:00+00:00",
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    await screen.findByText("Last checked for this file");
+
+    const pathNodes = Array.from(document.querySelectorAll("p.break-all")).filter(
+      (node) => node.textContent === longPath,
+    );
+    expect(pathNodes).toHaveLength(2);
+    for (const node of pathNodes) {
+      expect(node).toHaveClass("break-all");
+    }
+  });
+
   it("quick scan shows in-flight state and then success summary", async () => {
     const deferred = createDeferred<{ data: { run_id: string; scan_mode: "FAST"; eligible_file_count: number; scanned_count: number; skipped_count: number; issues_found: number; full_rescan: boolean } }>();
     mocks.startIntegrityScan.mockReturnValueOnce(deferred.promise);


### PR DESCRIPTION
## Summary
- prevent long file paths from overflowing the Integrity file detail panel
- use \`break-all\` CSS to wrap long unbroken paths at container edges
- consistent with existing \`quarantine_path\` handling already in the same page

## What changed
- added \`break-all\` class to \`absolute_path\` display in:
  - issues list item rows (issue list)
  - selected file detail panel

## Scope protection
Did not change:
- Integrity workflow behavior
- backend/API behavior
- unrelated UI surfaces

## Validation
- \`cd operator_console/gui_app && npx vitest run src/test/integrity-page.test.tsx\`

## Related
- #136
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
