### PR TITLE
feat(gui): align Duplicate Review header with current shell style

### DIFF
--- a/operator_console/gui_app/src/pages/DuplicatesPage.tsx
+++ b/operator_console/gui_app/src/pages/DuplicatesPage.tsx
@@ -10,7 +10,7 @@ import { DuplicateFocusCard } from "@/components/duplicates/DuplicateFocusCard";
 import { DuplicateMediaPreview } from "@/components/duplicates/DuplicateMediaPreview";
 import { DuplicateQueueItem } from "@/components/duplicates/DuplicateQueueItem";
 import { DuplicateReviewActionBar } from "@/components/duplicates/DuplicateReviewActionBar";
-import { TopSurfaceHeader } from "@/components/layout/TopSurfaceHeader";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -1514,17 +1514,25 @@ export default function DuplicatesPage() {
           : "max-w-[120rem] gap-3 px-3 py-3 sm:px-4 lg:px-5",
       )}
     >
-      <div data-page-header data-testid="duplicates-page-header">
-        <TopSurfaceHeader
-          badge="Duplicate Review"
-          title="Work duplicate decisions in focused steps."
-          description="Compare duplicates, move extra copies to the Recycle Bin, restore them if needed, and keep playback review separate."
-          icon={Copy}
-          density="compact"
-          className="rounded-[24px]"
-          contentClassName="px-4 py-3 sm:px-4 lg:px-5 lg:py-4"
-        />
-      </div>
+      <section
+        data-page-header
+        data-testid="duplicates-page-header"
+        className="rounded-[24px] border border-border/70 bg-card/95 px-4 py-3 shadow-sm sm:px-4 lg:px-5 lg:py-4"
+      >
+        <div className="space-y-3">
+          <Badge variant="outline" className="w-fit rounded-full px-3 py-1 text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+            Duplicate Review
+          </Badge>
+          <div className="space-y-1.5">
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+              Work duplicate decisions in focused steps.
+            </h1>
+            <p className="max-w-4xl text-sm leading-6 text-muted-foreground">
+              Compare duplicates, move extra copies to the Recycle Bin, restore them if needed, and keep playback review separate.
+            </p>
+          </div>
+        </div>
+      </section>
 
       {duplicatesQuery.error && (
         <ErrorAlert message={getErrorMessage(duplicatesQuery.error) || "Failed to load duplicate groups"} />


### PR DESCRIPTION
## Summary
- replace Duplicate Review's heavier header treatment with a lighter orientation-only header
- preserve the current Duplicate Review structural cleanup and separate section navigation
- align Duplicate Review presentation more closely with the current shell direction

## What changed
- removed the local `TopSurfaceHeader` usage from `DuplicatesPage`
- added a lighter local header section that keeps:
  - `Duplicate Review` badge
  - existing title
  - existing description
- preserved the separate tab strip below the header

## Scope protection
Did not change:
- Duplicate Review workflow behavior
- filter logic
- tab behavior
- page body structure
- shared shell behavior
- shared header-component design

## Validation
`cd operator_console/gui_app && npm run test -- src/test/duplicates-page.test.tsx`

## Related
#134
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
