### PR TITLE
fix(gui): contain Integrity raw diagnostic detail overflow

### DIFF
--- a/operator_console/gui_app/src/pages/IntegrityPage.tsx
+++ b/operator_console/gui_app/src/pages/IntegrityPage.tsx
@@ -661,7 +661,7 @@ export default function IntegrityPage() {
                         <p className="font-medium">{signal.signal_type}</p>
                       </div>
                       <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">{signal.severity}</p>
-                      <pre className="mt-2 overflow-x-auto rounded-lg bg-muted p-3 text-xs">
+                      <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] rounded-lg border border-border/60 bg-muted/40 p-3 font-mono text-xs">
                         {JSON.stringify(signal.details, null, 2)}
                       </pre>
                     </div>

--- a/operator_console/gui_app/src/test/integrity-page.test.tsx
+++ b/operator_console/gui_app/src/test/integrity-page.test.tsx
@@ -234,6 +234,46 @@ describe("IntegrityPage", () => {
     expect(pathNodes[1]).toHaveClass("break-all");
   });
 
+  it("wraps long diagnostic values in the file detail console while keeping the full text visible", async () => {
+    const longDiagnostic = "ffmpeg-error-" + "x".repeat(240);
+
+    mocks.getIntegrityFile.mockResolvedValueOnce({
+      data: {
+        check_id: "check-1",
+        file_instance_id: "file-1",
+        absolute_path: "/media/problem.mp4",
+        status: "BROKEN",
+        confidence: 0.93,
+        last_checked_at: "2026-03-25T09:00:00+00:00",
+        probe_status: "FAILED",
+        decode_status: "SKIPPED",
+        reviewed_decision: "MARK_OK",
+        reviewed_at: "2026-03-25T11:00:00+00:00",
+        signals: [
+          {
+            signal_type: "ffprobe_failed",
+            severity: "error",
+            details: { stderr: longDiagnostic },
+            created_at: "2026-03-25T10:00:00+00:00",
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    const diagnosticNode = await screen.findByText(longDiagnostic, { exact: false });
+    const diagnosticConsole = diagnosticNode.closest("pre");
+
+    expect(diagnosticConsole).not.toBeNull();
+    expect(diagnosticConsole).toHaveClass("overflow-x-auto");
+    expect(diagnosticConsole).toHaveClass("whitespace-pre-wrap");
+    expect(diagnosticConsole).toHaveClass("break-words");
+    expect(diagnosticConsole).toHaveClass("border");
+    expect(diagnosticConsole).toHaveClass("font-mono");
+    expect(diagnosticConsole).toHaveClass("[overflow-wrap:anywhere]");
+  });
+
   it("quick scan shows in-flight state and then success summary", async () => {
     const deferred = createDeferred<{ data: { run_id: string; scan_mode: "FAST"; eligible_file_count: number; scanned_count: number; skipped_count: number; issues_found: number; full_rescan: boolean } }>();
     mocks.startIntegrityScan.mockReturnValueOnce(deferred.promise);


### PR DESCRIPTION
## Summary
- finish the remaining #136 Integrity overflow fix by containing the raw diagnostic/error detail surface
- preserve full diagnostic text while preventing horizontal bleed
- keep the change local to the remaining problematic field

## What changed
- updated the `signal.details` surface in `IntegrityPage` to render inside a bounded raw-text block
- applied:
  - `pre`
  - `overflow-x-auto`
  - `whitespace-pre-wrap`
  - `[overflow-wrap:anywhere]`
  - `break-words`
  - monospace + muted/bordered styling
- left unrelated Integrity fields unchanged

## Scope protection
Did not change:
- backend/API behavior
- wider Integrity workflow
- unrelated fields or page redesign

## Validation
`cd operator_console/gui_app && npm run test -- src/test/integrity-page.test.tsx`

## Related
#136
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
