### PR TITLE
feat(gui): clarify Playback Issues bounded result set

### DIFF
--- a/operator_console/gui_app/src/pages/DuplicatesPage.tsx
+++ b/operator_console/gui_app/src/pages/DuplicatesPage.tsx
@@ -749,6 +749,7 @@ export default function DuplicatesPage() {
   );
   const brokenIssueCount = duplicatePlaybackGroups.reduce((sum, entry) => sum + entry.brokenCount, 0);
   const suspectIssueCount = duplicatePlaybackGroups.reduce((sum, entry) => sum + entry.suspectCount, 0);
+  const linkedPlaybackIssueCount = brokenIssueCount + suspectIssueCount;
   const reviewProgressLabel =
     selectedOverallIndex >= 0 ? `${selectedOverallIndex + 1} of ${sortedGroups.length}` : `0 of ${sortedGroups.length}`;
   const reviewMetaLine = selected
@@ -2313,9 +2314,11 @@ export default function DuplicatesPage() {
                       <div>
                         <p className="text-sm font-semibold text-foreground">Playback issues in duplicate groups</p>
                         <p className="text-sm text-muted-foreground">Review duplicate-linked playback exceptions here, then choose whether to continue duplicate review or open Integrity Review.</p>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          Showing the first {DUPLICATES_PLAYBACK_ISSUES_PAGE_SIZE} fetched integrity issues linked to duplicate groups.
-                        </p>
+                        {linkedPlaybackIssueCount > 0 ? (
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            Showing the first {DUPLICATES_PLAYBACK_ISSUES_PAGE_SIZE} fetched integrity issues; results are filtered to those linked to duplicate groups.
+                          </p>
+                        ) : null}
                       </div>
                       <div className="flex flex-wrap gap-2">
                         <StatusBadge label={`${duplicatePlaybackGroups.length} group${duplicatePlaybackGroups.length === 1 ? "" : "s"} with playback issues`} severity="neutral" />

--- a/operator_console/gui_app/src/pages/DuplicatesPage.tsx
+++ b/operator_console/gui_app/src/pages/DuplicatesPage.tsx
@@ -2313,6 +2313,9 @@ export default function DuplicatesPage() {
                       <div>
                         <p className="text-sm font-semibold text-foreground">Playback issues in duplicate groups</p>
                         <p className="text-sm text-muted-foreground">Review duplicate-linked playback exceptions here, then choose whether to continue duplicate review or open Integrity Review.</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Showing the first {DUPLICATES_PLAYBACK_ISSUES_PAGE_SIZE} fetched integrity issues linked to duplicate groups.
+                        </p>
                       </div>
                       <div className="flex flex-wrap gap-2">
                         <StatusBadge label={`${duplicatePlaybackGroups.length} group${duplicatePlaybackGroups.length === 1 ? "" : "s"} with playback issues`} severity="neutral" />

--- a/operator_console/gui_app/src/test/duplicates-page.test.tsx
+++ b/operator_console/gui_app/src/test/duplicates-page.test.tsx
@@ -1619,7 +1619,9 @@ describe("DuplicatesPage", () => {
     expect(topControls.nextElementSibling).toBe(issuesList);
     expect(screen.getByText("Playback issues in duplicate groups")).toBeInTheDocument();
     expect(
-      screen.getByText(`Showing the first ${DUPLICATES_PLAYBACK_ISSUES_PAGE_SIZE} fetched integrity issues linked to duplicate groups.`),
+      screen.getByText(
+        `Showing the first ${DUPLICATES_PLAYBACK_ISSUES_PAGE_SIZE} fetched integrity issues; results are filtered to those linked to duplicate groups.`,
+      ),
     ).toBeInTheDocument();
     expect(within(topControls).getByRole("button", { name: "Switch to review tab" })).toBeInTheDocument();
     expect(within(topControls).getByRole("link", { name: "Integrity review" })).toBeInTheDocument();

--- a/operator_console/gui_app/src/test/duplicates-page.test.tsx
+++ b/operator_console/gui_app/src/test/duplicates-page.test.tsx
@@ -1618,6 +1618,9 @@ describe("DuplicatesPage", () => {
     expect(topControls).toBeInTheDocument();
     expect(topControls.nextElementSibling).toBe(issuesList);
     expect(screen.getByText("Playback issues in duplicate groups")).toBeInTheDocument();
+    expect(
+      screen.getByText(`Showing the first ${DUPLICATES_PLAYBACK_ISSUES_PAGE_SIZE} fetched integrity issues linked to duplicate groups.`),
+    ).toBeInTheDocument();
     expect(within(topControls).getByRole("button", { name: "Switch to review tab" })).toBeInTheDocument();
     expect(within(topControls).getByRole("link", { name: "Integrity review" })).toBeInTheDocument();
     expect(screen.getAllByText("alpha-main.jpg").length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- add an explicit bounded-result notice to the Playback Issues summary area
- make it clear that the tab is showing only the first bounded set of fetched integrity issues
- keep the current request behavior unchanged

## What changed
- added a Playback Issues notice:
  - `Showing the first N fetched integrity issues linked to duplicate groups.`
- reused `DUPLICATES_PLAYBACK_ISSUES_PAGE_SIZE` so the message stays aligned with actual request behavior
- added/updated focused test coverage to assert the notice

## Scope protection
Did not change:
- backend paging rules
- pagination
- load-more behavior
- broader Duplicate Review redesign

## Validation
`cd operator_console/gui_app && npm run test -- src/test/duplicates-page.test.tsx`

## Related
#147
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
