### PR TITLE
chore(app-settings): de-scope benchmark max items from durable surface

### DIFF
--- a/media_manager/app/persistence/app_settings.py
+++ b/media_manager/app/persistence/app_settings.py
@@ -170,12 +170,6 @@ _CATALOG: dict[str, AppSettingDefinition] = {
         value_type="int",
         category="performance",
     ),
-    "benchmark_max_items": AppSettingDefinition(
-        key="benchmark_max_items",
-        env_var="MEDIA_MANAGER_BENCHMARK_MAX_ITEMS",
-        value_type="int",
-        category="performance",
-    ),
     "benchmark_poll_interval_seconds": AppSettingDefinition(
         key="benchmark_poll_interval_seconds",
         env_var="MEDIA_MANAGER_BENCHMARK_POLL_INTERVAL_SECONDS",
@@ -415,9 +409,9 @@ class AppSettingsService:
         logger: logging.Logger | None = None,
         session: Session | None = None,
     ) -> bool | str | float | int | list[str]:
+        definition = self.definition_for(key)
         if key not in RUNTIME_DUAL_READ_KEYS:
             raise AppSettingsValidationError(f"{key} is not enabled for runtime dual-read in this slice.")
-        definition = self.definition_for(key)
         snapshot = self.get_setting(key, session=session)
         if snapshot is not None:
             return snapshot.value
@@ -485,8 +479,6 @@ class AppSettingsService:
                 raise AppSettingsValidationError(f"{key} must be an integer.") from exc
             if key == "metadata_upsert_batch_size":
                 return min(max(parsed, 1), 50_000)
-            if key in {"benchmark_max_items"} and parsed <= 0:
-                raise AppSettingsValidationError(f"{key} must be > 0.")
             return int(parsed)
         if definition.value_type == "enum":
             normalized = str(value).strip()
@@ -543,8 +535,6 @@ class AppSettingsService:
             return self._parse_float_env(key, cleaned, default=30.0, strict=strict, positive=True, fallback_on_invalid=30.0)
         if key == "metadata_upsert_batch_size":
             return self._parse_int_env(key, cleaned, default=1000, strict=strict, clamp=(1, 50_000), positive=False)
-        if key == "benchmark_max_items":
-            return self._parse_int_env(key, cleaned, default=10_000, strict=strict, clamp=None, positive=True)
         if key == "benchmark_poll_interval_seconds":
             return self._parse_float_env(key, cleaned, default=2.0, strict=strict, positive=strict, fallback_on_invalid=None)
         if key == "benchmark_stale_after_seconds":

--- a/media_manager/tests/test_app_settings_runtime_dual_read.py
+++ b/media_manager/tests/test_app_settings_runtime_dual_read.py
@@ -257,8 +257,8 @@ def test_benchmark_runner_run_once_warns_and_falls_back_to_env_stale_after(
     assert any("using environment fallback" in line for line in calls)
 
 
-def test_benchmark_max_items_remains_not_enabled_for_runtime_dual_read(session_factory) -> None:
-    with pytest.raises(AppSettingsValidationError, match="not enabled for runtime dual-read"):
+def test_benchmark_max_items_is_not_part_of_the_app_settings_runtime_surface(session_factory) -> None:
+    with pytest.raises(AppSettingsValidationError, match="Unknown app setting key"):
         AppSettingsService(session_factory).resolve_runtime_value("benchmark_max_items")
 
 

--- a/media_manager/tests/test_app_settings_service.py
+++ b/media_manager/tests/test_app_settings_service.py
@@ -202,7 +202,6 @@ def test_bootstrap_from_env_parses_current_runtime_values(session_factory, monke
     monkeypatch.setenv("MEDIA_MANAGER_VIDEO_THUMBNAIL_CACHE_DIR", str((tmp_path / "thumbs").resolve()))
     monkeypatch.setenv("MEDIA_MANAGER_DB_RESET_INCLUDE_DYNAMIC", "false")
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARKS_ENABLED", "true")
-    monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_MAX_ITEMS", "10000")
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_POLL_INTERVAL_SECONDS", "2.0")
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_STALE_AFTER_SECONDS", "900")
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_WORKER_MODE", "forever")

--- a/media_manager/tests/test_service_layer_reads.py
+++ b/media_manager/tests/test_service_layer_reads.py
@@ -121,6 +121,7 @@ def test_admin_app_settings_non_dual_read_key_is_conservative(session_factory) -
     assert item["db_present"] is False
     assert item["runtime_dual_read_enabled"] is False
     assert item["effective_source"] is None
+    assert not any(entry["key"] == "benchmark_max_items" for entry in payload["items"])
 
 
 def test_admin_app_settings_sensitive_value_is_redacted(session_factory) -> None:

--- a/media_manager/tests/test_service_layer_reads.py
+++ b/media_manager/tests/test_service_layer_reads.py
@@ -121,6 +121,13 @@ def test_admin_app_settings_non_dual_read_key_is_conservative(session_factory) -
     assert item["db_present"] is False
     assert item["runtime_dual_read_enabled"] is False
     assert item["effective_source"] is None
+
+
+def test_admin_app_settings_omits_catalog_keys_removed_from_durable_surface(session_factory) -> None:
+    services = ReadServices(session_factory=session_factory, cache=_FakeCache(invalidations=[]))
+
+    payload = services.admin_app_settings()
+
     assert not any(entry["key"] == "benchmark_max_items" for entry in payload["items"])
 
 


### PR DESCRIPTION
## Summary
- Removes `benchmark_max_items` from the durable app settings catalog.
- Removes app-settings-specific env parsing/validation residue for the key.
- Updates tests so `benchmark_max_items` is treated as outside the durable app settings model.
- Preserves the existing env-only runtime benchmark guard via `MEDIA_MANAGER_BENCHMARK_MAX_ITEMS`.


## Authority model
Final classification:


`benchmark_max_items` remains env-only and is not part of the durable app settings surface.


This keeps it distinct from `benchmark_stale_after_seconds`, which remains a real DB-first dual-read runtime setting.


## Tests
- `./.venv/bin/python -m pytest media_manager/tests/test_app_settings_runtime_dual_read.py -q`
- `./.venv/bin/python -m pytest media_manager/tests/test_app_settings_service.py -q`
- `./.venv/bin/python -m pytest media_manager/tests/test_service_layer_reads.py -q`


## Issue
Closes #29
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
