### PR TITLE
chore(app-settings): keep planner mv opt-in env-only

### DIFF
--- a/media_manager/app/persistence/app_settings.py
+++ b/media_manager/app/persistence/app_settings.py
@@ -146,12 +146,6 @@ _CATALOG: dict[str, AppSettingDefinition] = {
         value_type="bool",
         category="ui",
     ),
-    "allow_planner_mv_reads": AppSettingDefinition(
-        key="allow_planner_mv_reads",
-        env_var="MEDIA_MANAGER_ALLOW_PLANNER_MV_READS",
-        value_type="bool",
-        category="ui",
-    ),
     "canonical_read_cache_enabled": AppSettingDefinition(
         key="canonical_read_cache_enabled",
         env_var="CANONICAL_READ_CACHE_ENABLED",
@@ -523,7 +517,6 @@ class AppSettingsService:
             "directory_picker_enabled",
             "video_thumbnails_enabled",
             "benchmarks_enabled",
-            "allow_planner_mv_reads",
             "canonical_read_cache_enabled",
             "db_reset_include_dynamic",
         }:

--- a/media_manager/tests/test_app_settings_runtime_dual_read.py
+++ b/media_manager/tests/test_app_settings_runtime_dual_read.py
@@ -89,6 +89,11 @@ def test_planner_metadata_batch_size_dual_read(session_factory, monkeypatch) -> 
     assert planner._get_metadata_batch_size() == 500
 
 
+def test_allow_planner_mv_reads_is_not_part_of_the_app_settings_runtime_surface(session_factory) -> None:
+    with pytest.raises(AppSettingsValidationError, match="Unknown app setting key"):
+        AppSettingsService(session_factory).resolve_runtime_value("allow_planner_mv_reads")
+
+
 def test_benchmark_runner_main_uses_db_first_worker_mode(
     session_factory, test_database_url: str, monkeypatch
 ) -> None:

--- a/media_manager/tests/test_service_layer_reads.py
+++ b/media_manager/tests/test_service_layer_reads.py
@@ -129,6 +129,7 @@ def test_admin_app_settings_omits_catalog_keys_removed_from_durable_surface(sess
     payload = services.admin_app_settings()
 
     assert not any(entry["key"] == "benchmark_max_items" for entry in payload["items"])
+    assert not any(entry["key"] == "allow_planner_mv_reads" for entry in payload["items"])
 
 
 def test_admin_app_settings_sensitive_value_is_redacted(session_factory) -> None:


### PR DESCRIPTION
## Summary
- Removes `allow_planner_mv_reads` from the durable app settings catalog.
- Updates app-settings tests so the key is treated as outside the durable app settings model.
- Preserves the existing env-only planner/materialized-read safety guard via `MEDIA_MANAGER_ALLOW_PLANNER_MV_READS`.

## Authority model
Final classification:

`allow_planner_mv_reads` remains env-only and is not part of the durable app settings surface.

This keeps the planner MV opt-in as a conservative deployment/runtime safety switch rather than a DB-backed runtime setting.

## Tests
- `./.venv/bin/python -m pytest media_manager/tests/test_mv_not_used_by_default.py -q`
- `./.venv/bin/python -m pytest media_manager/tests/test_app_settings_runtime_dual_read.py -q`
- `./.venv/bin/python -m pytest media_manager/tests/test_app_settings_service.py -q`
- `./.venv/bin/python -m pytest media_manager/tests/test_service_layer_reads.py -q`

## Issue
Closes #30
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
