### PR TITLE
chore(app-settings): keep primary storage roots env-only

### DIFF
--- a/media_manager/app/persistence/app_settings.py
+++ b/media_manager/app/persistence/app_settings.py
@@ -19,7 +19,6 @@ from media_manager.app.canonical.factory import resolve_default_policy_name
 from media_manager.app.core.config import (
     REQUIRED_METADATA_CODES,
     load_environment,
-    resolve_storage_roots,
 )
 from media_manager.app.core.errors import (
     AppSettingsValidationError,
@@ -103,18 +102,6 @@ _CATALOG: dict[str, AppSettingDefinition] = {
         env_var="MEDIA_MANAGER_TAG_NORMALIZATION_REMOVE_PUNCTUATION",
         value_type="bool",
         category="policy",
-    ),
-    "canonical_storage_path": AppSettingDefinition(
-        key="canonical_storage_path",
-        env_var="MEDIA_CANONICAL_STORAGE_PATH",
-        value_type="path",
-        category="storage",
-    ),
-    "duplicate_storage_path": AppSettingDefinition(
-        key="duplicate_storage_path",
-        env_var="MEDIA_DUPLICATE_STORAGE_PATH",
-        value_type="path",
-        category="storage",
     ),
     "video_thumbnail_cache_dir": AppSettingDefinition(
         key="video_thumbnail_cache_dir",
@@ -506,10 +493,6 @@ class AppSettingsService:
             return _split_csv_preserve_order(cleaned) if cleaned else []
         if key == "tag_normalization_remove_punctuation":
             return _truthy(cleaned or "0")
-        if key == "canonical_storage_path":
-            return str(resolve_storage_roots().canonical_root)
-        if key == "duplicate_storage_path":
-            return str(resolve_storage_roots().duplicate_root)
         if key == "video_thumbnail_cache_dir":
             path_value = cleaned if cleaned else str(Path(tempfile.gettempdir()) / "media-manager" / "video-thumbnails")
             return _normalize_path_string(path_value, field_name=key)

--- a/media_manager/tests/test_app_settings_runtime_dual_read.py
+++ b/media_manager/tests/test_app_settings_runtime_dual_read.py
@@ -72,6 +72,14 @@ def test_operator_console_video_thumbnail_settings_dual_read(session_factory, mo
     assert _video_thumbnail_cache_dir(session_factory) == (tmp_path / "db-thumbs").resolve()
 
 
+def test_primary_storage_roots_are_not_part_of_the_app_settings_runtime_surface(session_factory) -> None:
+    with pytest.raises(AppSettingsValidationError, match="Unknown app setting key"):
+        AppSettingsService(session_factory).resolve_runtime_value("canonical_storage_path")
+
+    with pytest.raises(AppSettingsValidationError, match="Unknown app setting key"):
+        AppSettingsService(session_factory).resolve_runtime_value("duplicate_storage_path")
+
+
 def test_planner_metadata_batch_size_dual_read(session_factory, monkeypatch) -> None:
     planner = PlanningService(session_factory)
     monkeypatch.setenv("METADATA_UPSERT_BATCH_SIZE", "2500")

--- a/media_manager/tests/test_app_settings_service.py
+++ b/media_manager/tests/test_app_settings_service.py
@@ -184,8 +184,6 @@ def test_bootstrap_from_env_parses_current_runtime_values(session_factory, monke
     service = AppSettingsService(session_factory)
 
     monkeypatch.setenv("MEDIA_REQUIRED_CODES", "OWNER,CONTEXT,TAKEN_DT")
-    monkeypatch.setenv("MEDIA_CANONICAL_STORAGE_PATH", str((tmp_path / "canonical").resolve()))
-    monkeypatch.setenv("MEDIA_DUPLICATE_STORAGE_PATH", str((tmp_path / "duplicates").resolve()))
     monkeypatch.setenv("MEDIA_MANAGER_TAG_NORMALIZATION_REMOVE_PUNCTUATION", "0")
     monkeypatch.setenv("MEDIA_CANONICAL_POLICY", "FIRST_SEEN")
     monkeypatch.setenv("MEDIA_PREFERRED_ROOTS", "")
@@ -230,8 +228,6 @@ def test_bootstrap_from_env_parses_current_runtime_values(session_factory, monke
 
 def test_bootstrap_is_idempotent_and_skips_existing_rows(session_factory, monkeypatch, tmp_path: Path) -> None:
     service = AppSettingsService(session_factory)
-    monkeypatch.setenv("MEDIA_CANONICAL_STORAGE_PATH", str((tmp_path / "canonical").resolve()))
-    monkeypatch.setenv("MEDIA_DUPLICATE_STORAGE_PATH", str((tmp_path / "duplicates").resolve()))
 
     first = service.bootstrap_from_env()
     second = service.bootstrap_from_env()
@@ -243,8 +239,6 @@ def test_bootstrap_is_idempotent_and_skips_existing_rows(session_factory, monkey
 
 def test_bootstrap_rejects_invalid_enum(session_factory, monkeypatch, tmp_path: Path) -> None:
     service = AppSettingsService(session_factory)
-    monkeypatch.setenv("MEDIA_CANONICAL_STORAGE_PATH", str((tmp_path / "canonical").resolve()))
-    monkeypatch.setenv("MEDIA_DUPLICATE_STORAGE_PATH", str((tmp_path / "duplicates").resolve()))
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_WORKER_MODE", "invalid")
 
     with pytest.raises(AppSettingsValidationError):

--- a/media_manager/tests/test_service_layer_reads.py
+++ b/media_manager/tests/test_service_layer_reads.py
@@ -130,6 +130,8 @@ def test_admin_app_settings_omits_catalog_keys_removed_from_durable_surface(sess
 
     assert not any(entry["key"] == "benchmark_max_items" for entry in payload["items"])
     assert not any(entry["key"] == "allow_planner_mv_reads" for entry in payload["items"])
+    assert not any(entry["key"] == "canonical_storage_path" for entry in payload["items"])
+    assert not any(entry["key"] == "duplicate_storage_path" for entry in payload["items"])
 
 
 def test_admin_app_settings_sensitive_value_is_redacted(session_factory) -> None:


### PR DESCRIPTION
## Summary
- Removes `canonical_storage_path` and `duplicate_storage_path` from the durable app settings catalog.
- Keeps primary storage-root authority in env/bootstrap configuration.
- Preserves `video_thumbnail_cache_dir` as a DB-first dual-read app setting.
- Updates tests so the durable app settings surface reflects the intended storage-path authority split.

## Authority model
Final classification:

- `canonical_storage_path` → env-only
- `duplicate_storage_path` → env-only
- `video_thumbnail_cache_dir` → DB-first dual-read

This keeps deployment/filesystem topology concerns out of the durable runtime settings surface while preserving the lower-risk thumbnail cache setting.

## Tests
- `./.venv/bin/python -m pytest media_manager/tests/test_app_settings_runtime_dual_read.py -q`
- `./.venv/bin/python -m pytest media_manager/tests/test_app_settings_service.py -q`
- `./.venv/bin/python -m pytest media_manager/tests/test_service_layer_reads.py -q`

## Issue
Closes #32

Hard rules:
- Do not touch unrelated files.
- Do not change storage-root runtime behavior.
- Do not change `resolve_storage_roots()`.
- Do not migrate primary storage roots to DB-first dual-read.
- Do not make primary storage roots Admin-editable.
- Do not weaken or remove `video_thumbnail_cache_dir` dual-read behavior.
- Do not edit docs unless a test or existing repository convention requires it.
- Do not merge the PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harishkamathuk/media-manager/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
