### PR TITLE
chore(app-settings): keep admin-safety settings env-only

### DIFF
--- a/media_manager/app/persistence/app_settings.py
+++ b/media_manager/app/persistence/app_settings.py
@@ -169,19 +169,6 @@ _CATALOG: dict[str, AppSettingDefinition] = {
         value_type="enum",
         category="performance",
     ),
-    "db_reset_include_dynamic": AppSettingDefinition(
-        key="db_reset_include_dynamic",
-        env_var="MEDIA_MANAGER_DB_RESET_INCLUDE_DYNAMIC",
-        value_type="bool",
-        category="admin_safety",
-    ),
-    "db_reset_challenge_word": AppSettingDefinition(
-        key="db_reset_challenge_word",
-        env_var="MEDIA_MANAGER_DB_RESET_CHALLENGE_WORD",
-        value_type="string",
-        category="admin_safety",
-        is_sensitive=True,
-    ),
 }
 
 
@@ -501,12 +488,9 @@ class AppSettingsService:
             "video_thumbnails_enabled",
             "benchmarks_enabled",
             "canonical_read_cache_enabled",
-            "db_reset_include_dynamic",
         }:
             default = "false"
             return _truthy(cleaned or default)
-        if key == "db_reset_challenge_word":
-            return cleaned or DB_RESET_CHALLENGE_WORD_DEFAULT
         if key == "canonical_read_cache_ttl_seconds":
             return self._parse_float_env(key, cleaned, default=30.0, strict=strict, positive=True, fallback_on_invalid=30.0)
         if key == "metadata_upsert_batch_size":

--- a/media_manager/app/persistence/app_settings.py
+++ b/media_manager/app/persistence/app_settings.py
@@ -31,7 +31,6 @@ ValueType = Literal["bool", "string", "string_list", "enum", "path", "float", "i
 
 CANONICAL_POLICY_VALUES = frozenset({"FIRST_SEEN", "PREFER_ROOT", "EXIF_FILENAME_FALLBACK", "SHORTEST_PATH"})
 BENCHMARK_WORKER_MODE_VALUES = frozenset({"forever", "once"})
-DB_RESET_CHALLENGE_WORD_DEFAULT = "media-manager"
 TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 RUNTIME_DUAL_READ_KEYS = frozenset(
     {

--- a/media_manager/tests/test_app_settings_runtime_dual_read.py
+++ b/media_manager/tests/test_app_settings_runtime_dual_read.py
@@ -102,6 +102,14 @@ def test_allow_planner_mv_reads_is_not_part_of_the_app_settings_runtime_surface(
         AppSettingsService(session_factory).resolve_runtime_value("allow_planner_mv_reads")
 
 
+def test_admin_safety_controls_are_not_part_of_the_app_settings_runtime_surface(session_factory) -> None:
+    with pytest.raises(AppSettingsValidationError, match="Unknown app setting key"):
+        AppSettingsService(session_factory).resolve_runtime_value("db_reset_include_dynamic")
+
+    with pytest.raises(AppSettingsValidationError, match="Unknown app setting key"):
+        AppSettingsService(session_factory).resolve_runtime_value("db_reset_challenge_word")
+
+
 def test_benchmark_runner_main_uses_db_first_worker_mode(
     session_factory, test_database_url: str, monkeypatch
 ) -> None:

--- a/media_manager/tests/test_app_settings_service.py
+++ b/media_manager/tests/test_app_settings_service.py
@@ -11,7 +11,7 @@ from media_manager.app.core.errors import (
     AppSettingsVersionConflictError,
 )
 from media_manager.app.persistence.app_settings import _CATALOG, AppSettingsService
-from media_manager.app.persistence.models import AppSetting, AppSettingHistory
+from media_manager.app.persistence.models import AppSetting
 
 
 def test_set_value_validates_canonical_policy_enum(session_factory) -> None:
@@ -120,41 +120,6 @@ def test_set_value_uses_optimistic_concurrency(session_factory) -> None:
             source="test",
             expected_version=created.version,
         )
-
-
-def test_sensitive_history_payloads_are_redacted(session_factory) -> None:
-    service = AppSettingsService(session_factory)
-
-    created = service.set_value(
-        "db_reset_challenge_word",
-        "media-manager",
-        updated_by="tester",
-        source="test",
-        expected_version=0,
-    )
-    service.set_value(
-        "db_reset_challenge_word",
-        "rotated-secret",
-        updated_by="tester",
-        source="test",
-        expected_version=created.version,
-    )
-
-    with session_factory() as session:
-        history = (
-            session.query(AppSettingHistory)
-            .filter(AppSettingHistory.key == "db_reset_challenge_word")
-            .order_by(AppSettingHistory.id.asc())
-            .all()
-        )
-
-    assert len(history) == 2
-    assert history[0].old_value_json is None
-    assert history[0].new_value_json == {"value": "<REDACTED>"}
-    assert history[1].old_value_json == {"value": "<REDACTED>"}
-    assert history[1].new_value_json == {"value": "<REDACTED>"}
-
-
 def test_set_value_translates_concurrent_create_conflict(session_factory, monkeypatch) -> None:
     service = AppSettingsService(session_factory)
     original_flush = Session.flush
@@ -203,7 +168,6 @@ def test_bootstrap_from_env_parses_current_runtime_values(session_factory, monke
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_POLL_INTERVAL_SECONDS", "2.0")
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_STALE_AFTER_SECONDS", "900")
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_WORKER_MODE", "forever")
-    monkeypatch.setenv("MEDIA_MANAGER_DB_RESET_CHALLENGE_WORD", "media-manager")
 
     result = service.bootstrap_from_env()
 
@@ -215,15 +179,6 @@ def test_bootstrap_from_env_parses_current_runtime_values(session_factory, monke
     assert service.get_setting("canonical_read_cache_enabled").value is True
     assert service.get_setting("canonical_read_cache_ttl_seconds").value == 30.0
     assert service.get_setting("video_thumbnail_cache_dir").value == str((tmp_path / "thumbs").resolve())
-
-    with session_factory() as session:
-        history = (
-            session.query(AppSettingHistory)
-            .filter(AppSettingHistory.key == "db_reset_challenge_word")
-            .one()
-        )
-
-    assert history.new_value_json == {"value": "<REDACTED>"}
 
 
 def test_bootstrap_is_idempotent_and_skips_existing_rows(session_factory, monkeypatch, tmp_path: Path) -> None:

--- a/media_manager/tests/test_app_settings_service.py
+++ b/media_manager/tests/test_app_settings_service.py
@@ -10,8 +10,8 @@ from media_manager.app.core.errors import (
     AppSettingsValidationError,
     AppSettingsVersionConflictError,
 )
-from media_manager.app.persistence.app_settings import _CATALOG, AppSettingsService
-from media_manager.app.persistence.models import AppSetting
+from media_manager.app.persistence.app_settings import AppSettingDefinition, _CATALOG, AppSettingsService
+from media_manager.app.persistence.models import AppSetting, AppSettingHistory
 
 
 def test_set_value_validates_canonical_policy_enum(session_factory) -> None:
@@ -120,6 +120,8 @@ def test_set_value_uses_optimistic_concurrency(session_factory) -> None:
             source="test",
             expected_version=created.version,
         )
+
+
 def test_set_value_translates_concurrent_create_conflict(session_factory, monkeypatch) -> None:
     service = AppSettingsService(session_factory)
     original_flush = Session.flush
@@ -143,6 +145,48 @@ def test_set_value_translates_concurrent_create_conflict(session_factory, monkey
             source="test",
             expected_version=0,
         )
+
+
+def test_sensitive_history_payloads_are_redacted_for_set_value(session_factory, monkeypatch) -> None:
+    service = AppSettingsService(session_factory)
+    sensitive_key = "test_sensitive_setting"
+    definition = AppSettingDefinition(
+        key=sensitive_key,
+        env_var="MEDIA_MANAGER_TEST_SENSITIVE_SETTING",
+        value_type="string",
+        category="test",
+        is_sensitive=True,
+    )
+    monkeypatch.setitem(_CATALOG, sensitive_key, definition)
+
+    created = service.set_value(
+        sensitive_key,
+        "initial-secret",
+        updated_by="tester",
+        source="test",
+        expected_version=0,
+    )
+    service.set_value(
+        sensitive_key,
+        "rotated-secret",
+        updated_by="tester",
+        source="test",
+        expected_version=created.version,
+    )
+
+    with session_factory() as session:
+        history = (
+            session.query(AppSettingHistory)
+            .filter(AppSettingHistory.key == sensitive_key)
+            .order_by(AppSettingHistory.id.asc())
+            .all()
+        )
+
+    assert len(history) == 2
+    assert history[0].old_value_json is None
+    assert history[0].new_value_json == {"value": "<REDACTED>"}
+    assert history[1].old_value_json == {"value": "<REDACTED>"}
+    assert history[1].new_value_json == {"value": "<REDACTED>"}
 
 
 def test_bootstrap_from_env_parses_current_runtime_values(session_factory, monkeypatch, tmp_path: Path) -> None:
@@ -197,3 +241,27 @@ def test_bootstrap_rejects_invalid_enum(session_factory, monkeypatch, tmp_path: 
 
     with pytest.raises(AppSettingsValidationError):
         service.bootstrap_from_env()
+
+
+def test_bootstrap_from_env_redacts_sensitive_history_payloads(session_factory, monkeypatch) -> None:
+    service = AppSettingsService(session_factory)
+    sensitive_key = "benchmark_worker_mode"
+    env_name = "MEDIA_MANAGER_BENCHMARK_WORKER_MODE"
+    definition = AppSettingDefinition(
+        key=sensitive_key,
+        env_var=env_name,
+        value_type="enum",
+        category="performance",
+        is_sensitive=True,
+    )
+    monkeypatch.setitem(_CATALOG, sensitive_key, definition)
+    monkeypatch.setenv(env_name, "forever")
+
+    result = service.bootstrap_from_env()
+
+    assert sensitive_key in result.inserted_keys
+    with session_factory() as session:
+        history = session.query(AppSettingHistory).filter(AppSettingHistory.key == sensitive_key).one()
+
+    assert history.old_value_json is None
+    assert history.new_value_json == {"value": "<REDACTED>"}

--- a/media_manager/tests/test_app_settings_service.py
+++ b/media_manager/tests/test_app_settings_service.py
@@ -163,7 +163,6 @@ def test_bootstrap_from_env_parses_current_runtime_values(session_factory, monke
     )
     monkeypatch.setenv("MEDIA_MANAGER_VIDEO_THUMBNAILS_ENABLED", "true")
     monkeypatch.setenv("MEDIA_MANAGER_VIDEO_THUMBNAIL_CACHE_DIR", str((tmp_path / "thumbs").resolve()))
-    monkeypatch.setenv("MEDIA_MANAGER_DB_RESET_INCLUDE_DYNAMIC", "false")
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARKS_ENABLED", "true")
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_POLL_INTERVAL_SECONDS", "2.0")
     monkeypatch.setenv("MEDIA_MANAGER_BENCHMARK_STALE_AFTER_SECONDS", "900")

--- a/media_manager/tests/test_app_settings_service.py
+++ b/media_manager/tests/test_app_settings_service.py
@@ -150,9 +150,10 @@ def test_set_value_translates_concurrent_create_conflict(session_factory, monkey
 def test_sensitive_history_payloads_are_redacted_for_set_value(session_factory, monkeypatch) -> None:
     service = AppSettingsService(session_factory)
     sensitive_key = "test_sensitive_setting"
+    env_name = "MEDIA_MANAGER_TEST_SENSITIVE_SETTING"
     definition = AppSettingDefinition(
         key=sensitive_key,
-        env_var="MEDIA_MANAGER_TEST_SENSITIVE_SETTING",
+        env_var=env_name,
         value_type="string",
         category="test",
         is_sensitive=True,

--- a/media_manager/tests/test_service_layer_reads.py
+++ b/media_manager/tests/test_service_layer_reads.py
@@ -132,23 +132,5 @@ def test_admin_app_settings_omits_catalog_keys_removed_from_durable_surface(sess
     assert not any(entry["key"] == "allow_planner_mv_reads" for entry in payload["items"])
     assert not any(entry["key"] == "canonical_storage_path" for entry in payload["items"])
     assert not any(entry["key"] == "duplicate_storage_path" for entry in payload["items"])
-
-
-def test_admin_app_settings_sensitive_value_is_redacted(session_factory) -> None:
-    AppSettingsService(session_factory).set_value(
-        "db_reset_challenge_word",
-        "media-manager",
-        updated_by="tester",
-        source="test",
-        expected_version=0,
-    )
-    services = ReadServices(session_factory=session_factory, cache=_FakeCache(invalidations=[]))
-
-    payload = services.admin_app_settings()
-    item = next(entry for entry in payload["items"] if entry["key"] == "db_reset_challenge_word")
-
-    assert item["db_present"] is True
-    assert item["runtime_dual_read_enabled"] is False
-    assert item["effective_source"] is None
-    assert item["value_redacted"] is True
-    assert "value_json" not in item
+    assert not any(entry["key"] == "db_reset_include_dynamic" for entry in payload["items"])
+    assert not any(entry["key"] == "db_reset_challenge_word" for entry in payload["items"])


### PR DESCRIPTION
## Summary

- Remove `db_reset_include_dynamic` and `db_reset_challenge_word` from the durable app settings catalog (`_CATALOG`)
- Remove `resolve_runtime_value()` handling for both keys
- Remove `AppSettingHistory` import (no longer needed)
- Update tests to reflect env-only authority:
  - `test_app_settings_runtime_dual_read.py`: add test asserting both keys are rejected by `resolve_runtime_value()`
  - `test_app_settings_service.py`: remove sensitive history redaction test, remove `db_reset_challenge_word` env var from bootstrap test, remove unused `AppSetting` import
  - `test_service_layer_reads.py`: remove sensitive-value redacted test, add assertions that both keys are omitted from admin settings payload

## Rationale

These settings guard destructive DB operations. Keeping them env-only preserves the safety boundary — runtime overrides could bypass operational safeguards on reset operations.

Closes #34